### PR TITLE
Addition of Option for Unifi Advanced Configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,6 +150,19 @@ This article explains in detail how to use the UniFi Site Export Wizard
 to quickly and easily export sites from one Controller
 (including configuration and devices) to another (e.g., this add-on).
 
+## Using Advanced Configuration
+
+You can use the advanced configuration via config.gateway.json as outlined 
+in this tutorial from Ubiquiti:
+
+<https://help.ubnt.com/hc/en-us/articles/215458888-UniFi-USG-Advanced-Configuration>
+
+The folder to copy your config.gateway.json is in `/backup/unifi/config`. 
+You will have to choose your site you wish to configurate. (Standard = Default)
+You can access this folder using the normal Hass.io methods 
+(e.g., using Samba, Terminal, SSH).
+
+
 ## Known issues and limitations
 
 - The AP seems stuck in "adopting" state: Please read the installation

--- a/unifi/rootfs/etc/cont-init.d/unifi.sh
+++ b/unifi/rootfs/etc/cont-init.d/unifi.sh
@@ -25,10 +25,10 @@ rm -fr /usr/lib/unifi/data/backup
 ln -s /backup/unifi /usr/lib/unifi/data/backup
 
 #Enables the gateway customization via config.gateway.json
-if ! bashio::fs.directory_exists '/config/unifi'; then
-    mkdir -p /config/unifi
+if ! bashio::fs.directory_exists '/backup/unifi/config'; then
+    mkdir -p /backup/unifi/confif
 fi    
-ln -s /config/unifi /usr/lib/unifi/data/sites/default
+ln -s /backup/unifi/config /usr/lib/unifi/data/sites/
 
 # Enable small files on MongoDB
 if ! bashio::fs.file_exists "${properties}"; then

--- a/unifi/rootfs/etc/cont-init.d/unifi.sh
+++ b/unifi/rootfs/etc/cont-init.d/unifi.sh
@@ -24,6 +24,12 @@ fi
 rm -fr /usr/lib/unifi/data/backup
 ln -s /backup/unifi /usr/lib/unifi/data/backup
 
+#Enables the gateway customization via config.gateway.json
+if ! bashio::fs.directory_exists '/config/unifi'; then
+    mkdir -p /config/unifi
+fi    
+ln -s /config/unifi /usr/lib/unifi/data/sites/default
+
 # Enable small files on MongoDB
 if ! bashio::fs.file_exists "${properties}"; then
     touch "${properties}"

--- a/unifi/rootfs/etc/cont-init.d/unifi.sh
+++ b/unifi/rootfs/etc/cont-init.d/unifi.sh
@@ -26,7 +26,7 @@ ln -s /backup/unifi /usr/lib/unifi/data/backup
 
 #Enables the gateway customization via config.gateway.json
 if ! bashio::fs.directory_exists '/backup/unifi/config'; then
-    mkdir -p /backup/unifi/confif
+    mkdir -p /backup/unifi/config
 fi    
 ln -s /backup/unifi/config /usr/lib/unifi/data/sites/
 


### PR DESCRIPTION
# Proposed Changes

> (Describe the changes and rationale behind them)
A symbolic link to the sites folder so user can use the custom configuration in their sites.
The symbolic link leads to a subfolder (backup/unifi/config) so that during a snapshot this will be ignored.
## Related Issues

> ([Github link][autolink-references] to related issues or pull requests)
https://github.com/hassio-addons/addon-unifi/issues/35

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/
https://help.ubnt.com/hc/en-us/articles/215458888-UniFi-USG-Advanced-Configuration

<blockquote><img src="https://theme.zdassets.com/theme_assets/77613/ff7ff89edfceb228b54443702ffba57c08d686fc.png" width="48" align="right"><div>Ubiquiti Networks Support and Help Center</div><div><strong><a href="https://help.ubnt.com">Ubiquiti Help Center</a></strong></div><div>Support Center for Ubiquiti -- Learn about our products, view online documentation, and get the latest downloads.</div></blockquote>