### PR TITLE
:arrow_up: Upgrade UniFi Controller to 5.12.35

### DIFF
--- a/unifi/Dockerfile
+++ b/unifi/Dockerfile
@@ -29,7 +29,7 @@ RUN \
         openjdk-8-jdk-headless=8u222-b10-1ubuntu1~18.04.1 \
     \
     && curl -J -L -o /tmp/unifi.deb \
-        "https://dl.ubnt.com/unifi/5.12.22/unifi_sysvinit_all.deb" \
+        "https://dl.ui.com/unifi/5.12.35/unifi_sysvinit_all.deb" \
     \
     && dpkg --install /tmp/unifi.deb \
     \


### PR DESCRIPTION
# Proposed Changes

Update the Unifi controller to version 5.12.35

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/