### PR TITLE
:arrow_up: upgrades Unifi Controller to 5.13.29

### DIFF
--- a/unifi/Dockerfile
+++ b/unifi/Dockerfile
@@ -29,7 +29,7 @@ RUN \
         openjdk-8-jdk-headless=8u252-b09-1~18.04 \
     \
     && curl -J -L -o /tmp/unifi.deb \
-        "https://dl.ui.com/unifi/5.12.72/unifi_sysvinit_all.deb" \
+        "https://dl.ui.com/unifi/5.13.29/unifi_sysvinit_all.deb" \
     \
     && dpkg --install /tmp/unifi.deb \
     \


### PR DESCRIPTION


# Proposed Changes

upgrades Unifi Controller to 5.13.29
## Related Issues

> ([Github link][autolink-references] to related issues or pull requests)

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/