### PR TITLE
Bump Unifi Controller to version 5.14.22

### DIFF
--- a/unifi/Dockerfile
+++ b/unifi/Dockerfile
@@ -30,7 +30,7 @@ RUN \
         openjdk-8-jdk-headless=8u252-b09-1~18.04 \
     \
     && curl -J -L -o /tmp/unifi.deb \
-        "https://dl.ui.com/unifi/5.13.32/unifi_sysvinit_all.deb" \
+        "https://dl.ui.com/unifi/5.14.22/unifi_sysvinit_all.deb" \
     \
     && dpkg --install /tmp/unifi.deb \
     \


### PR DESCRIPTION
# Proposed Changes

> Bump Unifi Controller to version 5.14.22

Change log: https://community.ui.com/releases/UniFi-Network-Controller-5-14-22/65337b17-f6e4-4f91-b78e-a4db05826e41

Also working DL-link but cloning the repo to /addons won't show up as local addon so can't seem to test this.