### PR TITLE
:arrow_up: Upgrades UniFi Controller to v6.0.27

### DIFF
--- a/unifi/Dockerfile
+++ b/unifi/Dockerfile
@@ -30,7 +30,7 @@ RUN \
         openjdk-8-jdk-headless=8u265-b01-0ubuntu2~18.04 \
     \
     && curl -J -L -o /tmp/unifi.deb \
-        "https://dl.ui.com/unifi/6.0.23/unifi_sysvinit_all.deb" \
+        "https://dl.ui.com/unifi/6.0.27-e23884806a/unifi_sysvinit_all.deb" \
     \
     && dpkg --install /tmp/unifi.deb \
     \


### PR DESCRIPTION
# Proposed Changes

6.0.23 has a bug where VLANs behind a UAP downlink won't connect. This is affecting one of my installations. It was fixed in 6.0.26, but there are other various bugfixes in 6.0.27

https://community.ui.com/releases/UniFi-Network-Controller-6-0-26/7298f408-d9bf-48d7-b92c-a29c5b73b769
https://community.ui.com/releases/UniFi-Network-Controller-6-0-27/969b5662-b647-4e11-84cc-a10857a8ece5