### PR TITLE
USG Advanced Configuration using config.gateway.json

### DIFF
--- a/unifi/DOCS.md
+++ b/unifi/DOCS.md
@@ -127,6 +127,18 @@ you can manually adopt a device by following these steps:
 - `$ set-inform http://<IP of Hassio>:<controller port (default:8080)>/inform`
   - for example `$ set-inform http://192.168.1.14:8080/inform`
 
+## USG Advanced Configuration using config.gateway.json
+
+The Unifi Security Gateway (USG and USG-PRO-4) can receive custom settings that
+aren't available in the web GUI:
+
+<https://help.ubnt.com/hc/en-us/articles/215458888-UniFi-USG-Advanced-Configuration>
+
+This addon allows you to provide and modify this file by placing it in
+`/config/unifi/sites/<site_ID>/config.gateway.json`
+
+Replace `<site_ID>` according to the above documentation from Unifi.
+
 ## Known issues and limitations
 
 - The AP seems stuck in "adopting" state: Please read the installation

--- a/unifi/config.json
+++ b/unifi/config.json
@@ -8,7 +8,7 @@
   "startup": "services",
   "arch": ["aarch64", "amd64", "armv7", "i386"],
   "init": false,
-  "map": ["backup:rw", "ssl"],
+  "map": ["backup:rw", "config:ro", "ssl"],
   "boot": "auto",
   "ports": {
     "161/udp": null,

--- a/unifi/rootfs/etc/cont-init.d/unifi.sh
+++ b/unifi/rootfs/etc/cont-init.d/unifi.sh
@@ -18,10 +18,10 @@ fi
 rm -fr /usr/lib/unifi/data
 ln -s /data/unifi/data /usr/lib/unifi/data
 
-# Link gateway.config.json from sites folder in /config/unifi
+# Link config.gateway.json from sites folder in /config/unifi
 if bashio::fs.directory_exists '/config/unifi/sites'; then
     mkdir -p /usr/lib/unifi/data/sites
-    for file in /config/unifi/sites/*/gateway.config.json; do
+    for file in /config/unifi/sites/*/config.gateway.json; do
         if bashio::fs.file_exists "${file}"; then
             site=$(basename $(dirname "${file}"))
             mkdir -p "/usr/lib/unifi/data/sites/${site}"

--- a/unifi/rootfs/etc/cont-init.d/unifi.sh
+++ b/unifi/rootfs/etc/cont-init.d/unifi.sh
@@ -18,6 +18,18 @@ fi
 rm -fr /usr/lib/unifi/data
 ln -s /data/unifi/data /usr/lib/unifi/data
 
+# Link gateway.config.json from sites folder in /config/unifi
+if bashio::fs.directory_exists '/config/unifi/sites'; then
+    mkdir -p /usr/lib/unifi/data/sites
+    for file in /config/unifi/sites/*/gateway.config.json; do
+        if bashio::fs.file_exists "${file}"; then
+            site=$(basename $(dirname "${file}"))
+            mkdir -p "/usr/lib/unifi/data/sites/${site}"
+            ln -f -s "${file}" "/usr/lib/unifi/data/sites/${site}/"
+        fi
+    done
+fi
+
 if ! bashio::fs.directory_exists '/backup/unifi'; then
     mkdir -p /backup/unifi
 fi


### PR DESCRIPTION
# Proposed Changes

Advanced features of the Unifi Security Gateway can only be set by manually editing/providing a json config in the right folder below the unifi data/sites directory. This is not an accessible location in the hassio container structure, so this places it in the /config directory which users can edit, and creates symlinks to the right location.

This is my take on what was also discussed in #35 and #38 but using /config/unifi/sites/*/config.gateway.json with support for multiple and non-default sites.


[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/