### PR TITLE
⬆️ Upgrade UniFi Controller v6.0.36

### DIFF
--- a/unifi/Dockerfile
+++ b/unifi/Dockerfile
@@ -30,7 +30,7 @@ RUN \
         openjdk-8-jdk-headless=8u265-b01-0ubuntu2~18.04 \
     \
     && curl -J -L -o /tmp/unifi.deb \
-        "https://dl.ui.com/unifi/6.0.28-39f3b98a31/unifi_sysvinit_all.deb" \
+        "https://dl.ui.com/unifi/6.0.36/unifi_sysvinit_all.deb" \
     \
     && dpkg --install /tmp/unifi.deb \
     \


### PR DESCRIPTION
# Proposed Changes

Upgrade UniFi Controller to v6.0.36

https://community.ui.com/releases/UniFi-Network-Controller-6-0-36/9e57165b-3422-4fcf-ae02-13affcb388c8

## Related Issues

> ([Github link][autolink-references] to related issues or pull requests)

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/