### PR TITLE
⬆️ Upgrade UniFi Controller v6.0.43

### DIFF
--- a/unifi/Dockerfile
+++ b/unifi/Dockerfile
@@ -30,7 +30,7 @@ RUN \
         openjdk-8-jdk-headless=8u275-b01-0ubuntu1~18.04 \
     \
     && curl -J -L -o /tmp/unifi.deb \
-        "https://dl.ui.com/unifi/6.0.41/unifi_sysvinit_all.deb" \
+        "https://dl.ui.com/unifi/6.0.43/unifi_sysvinit_all.deb" \
     \
     && dpkg --install /tmp/unifi.deb \
     \


### PR DESCRIPTION
# Proposed Changes

Upgrade UniFi Controller v6.0.43
Release notes:
[Link](https://community.ui.com/releases/UniFi-Network-Controller-6-0-43/b28bb453-927a-4dd8-82f7-40af28505510)
Installed and working on fresh HA

## Related Issues

> ([Github link][autolink-references] to related issues or pull requests)

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/