### PR TITLE
Fix add-on description extraction

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -18,7 +18,7 @@ jobs:
     outputs:
       architectures: ${{ steps.information.outputs.architectures }}
       build: ${{ steps.information.outputs.build }}
-      description: ${{ steps.information.output.description }}
+      description: ${{ steps.information.outputs.description }}
       name: ${{ steps.information.outputs.name }}
       slug: ${{ steps.information.outputs.slug }}
       target: ${{ steps.information.outputs.target }}

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -25,7 +25,7 @@ jobs:
     outputs:
       architectures: ${{ steps.information.outputs.architectures }}
       build: ${{ steps.information.outputs.build }}
-      description: ${{ steps.information.output.description }}
+      description: ${{ steps.information.outputs.description }}
       environment: ${{ steps.release.outputs.environment }}
       name: ${{ steps.information.outputs.name }}
       slug: ${{ steps.information.outputs.slug }}


### PR DESCRIPTION
# Proposed Changes

Fix add-on description extraction from the configuration in the CI. The description is used for the resulting image, and now missing.
