### PR TITLE
Upgrade add-on base image to 6.1.1

### DIFF
--- a/unifi/Dockerfile
+++ b/unifi/Dockerfile
@@ -1,4 +1,4 @@
-ARG BUILD_FROM=ghcr.io/hassio-addons/ubuntu-base/amd64:6.0.0
+ARG BUILD_FROM=ghcr.io/hassio-addons/ubuntu-base/amd64:6.1.1
 # hadolint ignore=DL3006
 FROM ${BUILD_FROM}
 

--- a/unifi/build.json
+++ b/unifi/build.json
@@ -1,8 +1,8 @@
 {
   "build_from": {
-    "aarch64": "ghcr.io/hassio-addons/ubuntu-base/aarch64:6.0.0",
-    "amd64": "ghcr.io/hassio-addons/ubuntu-base/amd64:6.0.0",
-    "armv7": "ghcr.io/hassio-addons/ubuntu-base/armv7:6.0.0",
-    "i386": "ghcr.io/hassio-addons/ubuntu-base/i386:6.0.0"
+    "aarch64": "ghcr.io/hassio-addons/ubuntu-base/aarch64:6.1.1",
+    "amd64": "ghcr.io/hassio-addons/ubuntu-base/amd64:6.1.1",
+    "armv7": "ghcr.io/hassio-addons/ubuntu-base/armv7:6.1.1",
+    "i386": "ghcr.io/hassio-addons/ubuntu-base/i386:6.1.1"
   }
 }


### PR DESCRIPTION
# Proposed Changes

Upgrades the add-on base image to 6.1.1

Release notes: <https://github.com/hassio-addons/addon-ubuntu-base/releases/tag/v6.1.1>

