### PR TITLE
Map port 22 for SSH

### DIFF
--- a/unifi/config.json
+++ b/unifi/config.json
@@ -10,6 +10,7 @@
   "init": false,
   "map": ["backup:rw", "ssl"],
   "ports": {
+    "22/tcp": 8022,
     "161/udp": null,
     "1900/udp": null,
     "3478/udp": 3478,
@@ -22,6 +23,7 @@
     "10001/udp": 10001
   },
   "ports_description": {
+    "22/tcp": "Used for SSH",
     "161/udp": "Used for SNMP Access",
     "1900/udp": "L2 discoverable port",
     "3478/udp": "Used for STUN",


### PR DESCRIPTION
# Proposed Changes

Add mapping for SSH port.

Hopefully I understood the documentation correctly and mapped from the internal container (22) to 8022.

## Related Issues

As [explained in the forums](https://community.home-assistant.io/t/home-assistant-community-add-on-unifi-controller/56297/416?u=geertvanhorrik), sometimes there is need for port SSH on the *controller* (not the devices).

Original post:

> Having this issue which requires SSH access to the controller to fix :astonished:
> [USG L2TP issue - “Authentication Failed” | Ubiquiti Community](https://community.ui.com/questions/USG-L2TP-issue-Authentication-Failed/17ecd602-5c95-4b35-8dd6-7fcacbfd892c)
