### PR TITLE
⬆️ Upgrades openjdk-8-jdk-headless to 8u292-b10-0ubuntu1~18.04

### DIFF
--- a/unifi/Dockerfile
+++ b/unifi/Dockerfile
@@ -27,7 +27,7 @@ RUN \
         libcap2=1:2.25-1.2 \
         logrotate=3.11.0-0.1ubuntu1 \
         mongodb-server=1:2.6.10-0ubuntu1 \
-        openjdk-8-jdk-headless=8u282-b08-0ubuntu1~18.04 \
+        openjdk-8-jdk-headless=8u292-b10-0ubuntu1~18.04 \
     \
     && curl -J -L -o /tmp/unifi.deb \
         "https://dl.ui.com/unifi/6.1.71/unifi_sysvinit_all.deb" \


### PR DESCRIPTION
# Proposed Changes

Upgrades openjdk-8-jdk-headless to 8u292-b10-0ubuntu1~18.04