### PR TITLE
⬆ Upgrade UniFi Controller 6.2.23

### DIFF
--- a/unifi/Dockerfile
+++ b/unifi/Dockerfile
@@ -30,7 +30,7 @@ RUN \
         openjdk-8-jdk-headless=8u292-b10-0ubuntu1~18.04 \
     \
     && curl -J -L -o /tmp/unifi.deb \
-        "https://dl.ui.com/unifi/6.1.71/unifi_sysvinit_all.deb" \
+        "https://dl.ui.com/unifi/6.2.23/unifi_sysvinit_all.deb" \
     \
     && dpkg --install /tmp/unifi.deb \
     \


### PR DESCRIPTION
As of today this RC went to stable
https://community.ui.com/releases/UniFi-Network-Application-6-2-23/df89533b-184a-4fb7-b2c6-9f894b82df27#comment/85dcd21f-84b6-4967-bb8a-2ea349ead55e

# Proposed Changes

> update version from 6.1.71 to 6.2.23
   Tested ok in HA LAB environment(esxi)

## Related Issues
fixes #196
fixes #189
fixes #180

> ([Github link][autolink-references] to related issues or pull requests)

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/
