### PR TITLE
Upgrade controller to 6.2.25

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ This is an active open-source project. We are always open to people who want to
 use the code or contribute to it.
 
 We have set up a separate document containing our
-[contribution guidelines](CONTRIBUTING.md).
+[contribution guidelines](.github/CONTRIBUTING.md).
 
 Thank you for being involved! :heart_eyes:
 

--- a/unifi/Dockerfile
+++ b/unifi/Dockerfile
@@ -30,7 +30,7 @@ RUN \
         openjdk-8-jdk-headless=8u292-b10-0ubuntu1~18.04 \
     \
     && curl -J -L -o /tmp/unifi.deb \
-        "https://dl.ui.com/unifi/6.2.23/unifi_sysvinit_all.deb" \
+        "https://dl.ui.com/unifi/6.2.25/unifi_sysvinit_all.deb" \
     \
     && dpkg --install /tmp/unifi.deb \
     \


### PR DESCRIPTION
# Proposed Changes

Upgrade to [latest stable controller release](https://community.ui.com/releases/UniFi-Network-Application-6-2-25/d9cb0897-3ef4-4dda-a5d6-c07530ff8a86)

The current version, 6.2.23, is causing many issues. I think everything is related to this note under [known issues for the 6.2.23 release](https://community.ui.com/releases/UniFi-Network-Application-6-2-23/df89533b-184a-4fb7-b2c6-9f894b82df27): 
`You may experience a migration issue when upgrading from 6.1.71 to 6.2.23. You can upgrade to 6.2.17 before 6.2.23 as a workaround.`

The previous version for this addon was 6.1.71, so we skipped 6.2.17, which aligns with the database migration errors described by Ubiquiti.

I don't see any known issues or required versions in the upgrade notes for 6.2.25, and both the current add-on release (6.2.23) and the previous add-on release (6.1.71) are listed as supported upgrade paths:
```
Existing UniFi Network Applications must be on one of the following versions in order to upgrade directly to this version:
6.2.25 and earlier 6.2.x versions.
6.1.71 and earlier 6.1.x versions.
6.0.45 and earlier 6.0.x versions.
5.14.25 and earlier 5.14.x versions.
5.13.33 and earlier 5.13.x versions.
5.12.72 and earlier 5.12.x versions.
5.11.52 and earlier 5.11.x versions.
5.10.27 and earlier 5.10.x versions.
5.9.33 and earlier 5.9.x versions.
5.8.30 and earlier 5.8.x versions.
5.7.28 and earlier 5.7.x versions.
5.6.42 and earlier 5.6.x versions.
Most earlier versions are also supported for direct upgrade, going back to 3.1.0.
```

Full disclosure: I haven't tested this change yet, but expect that it should work as expected.

## Related Issues

#206
#205
