### PR TITLE
Bump mongodb and unifi-controller to fix #205

### DIFF
--- a/unifi/Dockerfile
+++ b/unifi/Dockerfile
@@ -26,11 +26,11 @@ RUN \
         jsvc=1.0.15-8 \
         libcap2=1:2.25-1.2 \
         logrotate=3.11.0-0.1ubuntu1 \
-        mongodb-server=1:2.6.10-0ubuntu1 \
+        mongodb-server=1:3.6.13-0ubuntu1 \
         openjdk-8-jdk-headless=8u292-b10-0ubuntu1~18.04 \
     \
     && curl -J -L -o /tmp/unifi.deb \
-        "https://dl.ui.com/unifi/6.2.23/unifi_sysvinit_all.deb" \
+        "https://dl.ui.com/unifi/6.2.25/unifi_sysvinit_all.deb" \
     \
     && dpkg --install /tmp/unifi.deb \
     \

--- a/unifi/config.json
+++ b/unifi/config.json
@@ -3,7 +3,7 @@
   "version": "dev",
   "slug": "unifi",
   "description": "Manage your UniFi network using a web browser",
-  "url": "https://github.com/sermayoral/addon-unifi",
+  "url": "https://github.com/hassio-addons/addon-unifi",
   "webui": "https://[HOST]:[PORT:8443]",
   "startup": "services",
   "arch": ["aarch64", "amd64", "armv7", "i386"],

--- a/unifi/config.json
+++ b/unifi/config.json
@@ -3,7 +3,7 @@
   "version": "dev",
   "slug": "unifi",
   "description": "Manage your UniFi network using a web browser",
-  "url": "https://github.com/hassio-addons/addon-unifi",
+  "url": "https://github.com/sermayoral/addon-unifi",
   "webui": "https://[HOST]:[PORT:8443]",
   "startup": "services",
   "arch": ["aarch64", "amd64", "armv7", "i386"],


### PR DESCRIPTION
# Proposed Changes

From 0.22.0 version, the unifi addon for Home Assistant has had a lot of problems when the addon restarts. The problems seem to be caused with a mongodb bug: https://stackoverflow.com/questions/22947465/mongodb-crashed-with-invalid-access-at-address-segmentation-fault-signal-11

In jacobalberty-unifi-docker repo they had same problem, and this was solved upgrading to a 6.2.23 unifi version, but it didn't work here. They seem to use latest version of mongodb, and this repo is using a 2.6.10 mongodb version.

I hope this changes fix the problem. I have not been able to test them, but I think it's a good starting point, let's see if between @frenck and everyone we can fix this problem once and for all.

Thank you guys!

## Related Issues

https://github.com/hassio-addons/addon-unifi/issues/205

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/
