### PR TITLE
🥶 Use cold backups

### DIFF
--- a/unifi/DOCS.md
+++ b/unifi/DOCS.md
@@ -158,6 +158,9 @@ you can manually adopt a device by following these steps:
   to open the required "range" of ports needed for this feature to work.
 - This add-on cannot support Ingress due to technical limitations of the
   UniFi software.
+- During making a backup of this add-on via Home Assistant, this add-on will
+  temporary shutdown and start up after the backup has finished. This prevents
+  data corruption during taking the backup.
 
 ## Changelog & Releases
 

--- a/unifi/config.json
+++ b/unifi/config.json
@@ -8,6 +8,7 @@
   "startup": "services",
   "arch": ["aarch64", "amd64"],
   "init": false,
+  "snapshot": "cold",
   "map": ["backup:rw", "ssl"],
   "ports": {
     "161/udp": null,


### PR DESCRIPTION
# Proposed Changes

Changes the backup (snapshot) mechanism for the Supervisor from hot -> cold.

This prevents corruption and restoration issues, however, it temporarily shuts down the add-on during backup. This behavior is added to the documentation.