### PR TITLE
🔥 Drop support for custom SSL certificates

### DIFF
--- a/unifi/DOCS.md
+++ b/unifi/DOCS.md
@@ -34,9 +34,6 @@ Example add-on configuration, with all available options:
 
 ```yaml
 log_level: info
-ssl: true
-certfile: fullchain.pem
-keyfile: privkey.pem
 memory_max: 2048
 memory_init: 512
 ```
@@ -60,26 +57,6 @@ Please note that each level automatically includes log messages from a
 more severe level, e.g., `debug` also shows `info` messages. By default,
 the `log_level` is set to `info`, which is the recommended setting unless
 you are troubleshooting.
-
-### Option: `ssl`
-
-Enables/Disables the use of a custom SSL (HTTPS) certificate with the in UniFi
-web interface. Set it `true` to enable it, `false` otherwise.
-
-**Note**: _When leaving this option disabled, UniFi will use a
-custom/self-signed SSL certificate._
-
-### Option: `certfile`
-
-The certificate file to use for SSL.
-
-**Note**: _The file MUST be stored in `/ssl/`, which is the default_
-
-### Option: `keyfile`
-
-The private key file to use for SSL.
-
-**Note**: _The file MUST be stored in `/ssl/`, which is the default_
 
 ### Option: `memory_max`
 
@@ -134,12 +111,6 @@ you can manually adopt a device by following these steps:
   in order for this add-on to work properly. Using the Ubiquiti Discovery
   Tool, or SSH'ing into the AP and setting the INFORM after adopting
   will resolve this. (see: _Manually adopting a device_)
-- This add-on does support ARM-based devices, nevertheless, they must
-  at least be an ARMv7 device. (Raspberry Pi 1 and Zero is not supported).
-- When using SSL, the following warning is shown in the add-on logs:
-  `Warning: The JKS keystore uses a proprietary format.`. This warning can
-  be safely ignored. There is nothing wrong and your add-on will function
-  normally.
 - The following error can show up in the log, but can be safely ignored:
 
   ```
@@ -148,8 +119,6 @@ you can manually adopt a device by following these steps:
     however, the add-on functions normally.
   ```
 
-- Due limitation, renewed SSL certificates are not picked up automatically.
-  You'd have to restart the add-on in order for UniFi to pick up the change.
 - Due to security policies in the UniFi Controller software, it is currently
   impossible to add the UniFI web interface to your Home Assistant frontend
   using a `panel_iframe`.

--- a/unifi/config.json
+++ b/unifi/config.json
@@ -9,7 +9,7 @@
   "arch": ["aarch64", "amd64"],
   "init": false,
   "snapshot": "cold",
-  "map": ["backup:rw", "ssl"],
+  "map": ["backup:rw"],
   "ports": {
     "161/udp": null,
     "1900/udp": null,
@@ -35,16 +35,8 @@
     "10001/udp": "Used for device discovery"
   },
   "hassio_api": true,
-  "options": {
-    "ssl": true,
-    "certfile": "fullchain.pem",
-    "keyfile": "privkey.pem"
-  },
   "schema": {
     "log_level": "list(trace|debug|info|notice|warning|error|fatal)?",
-    "ssl": "bool",
-    "certfile": "str",
-    "keyfile": "str",
     "memory_max": "int?",
     "memory_init": "int?"
   }

--- a/unifi/rootfs/etc/cont-init.d/unifi.sh
+++ b/unifi/rootfs/etc/cont-init.d/unifi.sh
@@ -5,12 +5,6 @@
 # ==============================================================================
 readonly KEYSTORE="/usr/lib/unifi/data/keystore"
 readonly properties="/data/unifi/data/system.properties"
-declare certfile
-declare keyfile
-declare root_chain
-declare tempcert
-
-bashio::config.require.ssl
 
 # Ensures the data of the UniFi controller is store outside the container
 if ! bashio::fs.directory_exists '/data/unifi/data'; then
@@ -36,94 +30,20 @@ sed -i \
     '/^unifi.db.extraargs=/{h;s/=.*/=--smallfiles/};${x;/^$/{s//unifi.db.extraargs=--smallfiles/;H};x}' \
     "${properties}"
 
-# Identrust cross-signed CA cert needed by the java keystore for import.
-# Can get original here: https://www.identrust.com/certificates/trustid/root-download-x3.html
-root_chain=$(cat <<-END
------BEGIN CERTIFICATE-----
-MIIDSjCCAjKgAwIBAgIQRK+wgNajJ7qJMDmGLvhAazANBgkqhkiG9w0BAQUFADA/
-MSQwIgYDVQQKExtEaWdpdGFsIFNpZ25hdHVyZSBUcnVzdCBDby4xFzAVBgNVBAMT
-DkRTVCBSb290IENBIFgzMB4XDTAwMDkzMDIxMTIxOVoXDTIxMDkzMDE0MDExNVow
-PzEkMCIGA1UEChMbRGlnaXRhbCBTaWduYXR1cmUgVHJ1c3QgQ28uMRcwFQYDVQQD
-Ew5EU1QgUm9vdCBDQSBYMzCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEB
-AN+v6ZdQCINXtMxiZfaQguzH0yxrMMpb7NnDfcdAwRgUi+DoM3ZJKuM/IUmTrE4O
-rz5Iy2Xu/NMhD2XSKtkyj4zl93ewEnu1lcCJo6m67XMuegwGMoOifooUMM0RoOEq
-OLl5CjH9UL2AZd+3UWODyOKIYepLYYHsUmu5ouJLGiifSKOeDNoJjj4XLh7dIN9b
-xiqKqy69cK3FCxolkHRyxXtqqzTWMIn/5WgTe1QLyNau7Fqckh49ZLOMxt+/yUFw
-7BZy1SbsOFU5Q9D8/RhcQPGX69Wam40dutolucbY38EVAjqr2m7xPi71XAicPNaD
-aeQQmxkqtilX4+U9m5/wAl0CAwEAAaNCMEAwDwYDVR0TAQH/BAUwAwEB/zAOBgNV
-HQ8BAf8EBAMCAQYwHQYDVR0OBBYEFMSnsaR7LHH62+FLkHX/xBVghYkQMA0GCSqG
-SIb3DQEBBQUAA4IBAQCjGiybFwBcqR7uKGY3Or+Dxz9LwwmglSBd49lZRNI+DT69
-ikugdB/OEIKcdBodfpga3csTS7MgROSR6cz8faXbauX+5v3gTt23ADq1cEmv8uXr
-AvHRAosZy5Q6XkjEGB5YGV8eAlrwDPGxrancWYaLbumR9YbK+rlmM6pZW87ipxZz
-R8srzJmwN0jP41ZL9c8PDHIyh8bwRLtTcm1D9SZImlJnt1ir/md2cXjbDaJWFBM5
-JDGFoqgCWjBH4d1QB7wCCZAA62RjYJsWvIjJEubSfZGL+T0yjWW06XyxV3bqxbYo
-Ob8VZRzI9neWagqNdwvYkQsEjgfbKbYK7p2CNTUQ
------END CERTIFICATE-----
-END
-)
-
-# Stop running this script if SSL is disabled
-if bashio::config.false 'ssl'; then
- exit 0
-fi
-
-# Initialize keystore, in case it does not exist yet
+# If there is no keystore yet, we are good to go
 if ! bashio::fs.file_exists "${KEYSTORE}"; then
-    bashio::log.debug 'Intializing keystore...'
-    keytool \
-        -genkey \
-        -keyalg RSA \
-        -alias unifi \
-        -keystore "${KEYSTORE}" \
-        -storepass aircontrolenterprise \
-        -keypass aircontrolenterprise \
-        -validity 1825 \
-        -keysize 4096 \
-        -dname "cn=UniFi" || \
-        bashio::exit.nok "Failed creating UniFi keystore"
+    # Prevent migration next time
+    touch /data/keystore_reset
+    bashio::exit.ok
 fi
 
-bashio::log.debug 'Injecting SSL certificate into the controller...'
-
-certfile="/ssl/$(bashio::config 'certfile')"
-keyfile="/ssl/$(bashio::config 'keyfile')"
-tempcert=$(mktemp)
-
-# Adds Identrust cross-signed CA cert in case of letsencrypt
-if [[ $(openssl x509 -noout -ocsp_uri -in "${certfile}") == *"letsencrypt"* ]]; then
-    echo "${root_chain}" > "${tempcert}"
-    cat "${certfile}" >> "${tempcert}"
-else
-    cat "${certfile}" > "${tempcert}"
+# If the keystore has never been reset, we are going to do that... once
+# This is a migration path, for people that previously had a custom SSL
+# certificate.
+# It will trigger a new self-signed certificate.
+# This logic can be removed and cleaned up at a later moment
+if ! bashio::fs.file_exists "/data/keystore_reset"; then
+    rm -f -r "${KEYSTORE}"
+    touch /data/keystore_reset
+    bashio::exit.ok
 fi
-
-bashio::log.debug 'Preparing certificate in a format UniFi accepts...'
-openssl pkcs12 \
-    -export  \
-    -passout pass:aircontrolenterprise \
-    -in "${tempcert}" \
-    -inkey "${keyfile}" \
-    -out "${tempcert}" \
-    -name unifi
-
-bashio::log.debug 'Removing existing certificate from UniFi protected keystore...'
-keytool \
-    -delete \
-    -alias unifi \
-    -keystore "${KEYSTORE}" \
-    -deststorepass aircontrolenterprise
-
-bashio::log.debug 'Inserting certificate into UniFi keystore...'
-keytool \
-    -trustcacerts \
-    -importkeystore \
-    -deststorepass aircontrolenterprise \
-    -destkeypass aircontrolenterprise \
-    -destkeystore "${KEYSTORE}" \
-    -srckeystore "${tempcert}" \
-    -srcstoretype PKCS12 \
-    -srcstorepass aircontrolenterprise \
-    -alias unifi
-
-# Cleanup
-rm -f "${tempcert}"

--- a/unifi/translations/en.yaml
+++ b/unifi/translations/en.yaml
@@ -4,20 +4,6 @@ configuration:
     name: Log level
     description: >-
       Controls the level of log details the add-on provides.
-  ssl:
-    name: SSL
-    description: >-
-      Enables/Disables SSL (HTTPS) on the web interface.
-  certfile:
-    name: Certificate file
-    description: >-
-      The certificate file to use for SSL. Note that this file must
-      exist in the /ssl/ folder.
-  keyfile:
-    name: Private key file
-    description: >-
-      The private key file to use for SSL. Note that this file must
-      exist in the /ssl/ folder.
   memory_max:
     name: Max Memory
     description: >-


### PR DESCRIPTION
# Proposed Changes

This PR drops support for custom SSL certificates. Handling them is problematic and has caused issues.

From this moment on the add-on will use a self-signed certificate (which will be migrated to if you have used a custom certificate before).

If you want to use a custom certificate, we would recommend using a reverse proxy in front of the UniFi Controller add-on.

## Related Issues

fixes #235
fixes #239
fixes #205

