### PR TITLE
🏎 Reduce default memory footprint

### DIFF
--- a/unifi/DOCS.md
+++ b/unifi/DOCS.md
@@ -65,7 +65,7 @@ is allowed to consume. By default, this is limited to 1 GB. You might want
 to increase this, in order to reduce CPU load or reduce this, in order
 to optimize your system for lower memory usage.
 
-This option takes the number of Megabyte, for example, the default is 1024.
+This option takes the number of Megabyte, for example, the default is 256.
 
 ### Option: `memory_init`
 
@@ -73,7 +73,7 @@ This option allows you to change the amount of memory the UniFi Controller
 will initially reserve/consume when starting. By default, this is limited to
 512M.
 
-This option takes the number of Megabyte, for example, the default is 512.
+This option takes the number of Megabyte, for example, the default is 128.
 
 ## Automated backups
 

--- a/unifi/rootfs/etc/services.d/unifi/run
+++ b/unifi/rootfs/etc/services.d/unifi/run
@@ -9,12 +9,12 @@ declare xms
 
 bashio::log.info 'Starting the UniFi Controller...'
 
-xmx=1024
+xmx=256
 if bashio::config.has_value 'memory_max'; then
     xmx=$(bashio::config 'memory_max')
 fi
 
-xms=512
+xms=128
 if bashio::config.has_value 'memory_init'; then
     xms=$(bashio::config 'memory_init')
 fi


### PR DESCRIPTION
# Proposed Changes

Reduces the default memory footprint by reducing the amount of memory we allow JVM to initialize and use.

Previous max: 1024, new max: 256
Previous init: 512, new init: 128

On my setup, it reduced the memory usage around 360Mb, while still working and responsive.


