### PR TITLE
⬇️  Downgrade MongoDB to 3.4 to provide an upgrade path

### DIFF
--- a/unifi/Dockerfile
+++ b/unifi/Dockerfile
@@ -9,13 +9,22 @@ SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 ARG BUILD_ARCH=amd64
 RUN \
     apt-get update \
+    && apt-get install -y --no-install-recommends \
+        gnupg2 \
     \
+    && curl -fsSL "https://www.mongodb.org/static/pgp/server-3.4.asc" \
+        | apt-key add -\
+    && echo "deb http://repo.mongodb.org/apt/ubuntu xenial/mongodb-org/3.4 multiverse" \
+        > /etc/apt/sources.list.d/mongodb.list \
+    \
+    && apt-get update \
     && apt-get install -y --no-install-recommends \
         binutils=2.30-21ubuntu1~18.04.5 \
         jsvc=1.0.15-8 \
         libcap2=1:2.25-1.2 \
+        libssl1.0.0=1.0.2n-1ubuntu5.6 \
         logrotate=3.11.0-0.1ubuntu1 \
-        mongodb-server=1:3.6.3-0ubuntu1.1 \
+        mongodb-org-server=3.4.24 \
         openjdk-8-jdk-headless=8u292-b10-0ubuntu1~18.04 \
     \
     && curl -J -L -o /tmp/unifi.deb \
@@ -23,6 +32,10 @@ RUN \
     \
     && dpkg --install /tmp/unifi.deb \
     \
+    && apt-get remove -y --purge \
+        gnupg2 \
+    \
+    && apt-get clean \
     && rm -fr \
         /tmp/* \
         /root/.gnupg \

--- a/unifi/Dockerfile
+++ b/unifi/Dockerfile
@@ -10,7 +10,7 @@ ARG BUILD_ARCH=amd64
 RUN \
     apt-get update \
     && apt-get install -y --no-install-recommends \
-        gnupg2 \
+        gnupg2=2.2.4-1ubuntu1.4 \
     \
     && curl -fsSL "https://www.mongodb.org/static/pgp/server-3.4.asc" \
         | apt-key add -\


### PR DESCRIPTION
# Proposed Changes

In order to provide a viable upgrade path for existing installations, this PR forces the installation of MongoDB 3.4.

This makes MongoDB take care of the migration. In a few months, this can be reverted, making the step to upgrade to MongoDB 3.6.
