### PR TITLE
Updates to documentation after dropped 32-bit support

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,8 +33,7 @@ you to manage your UniFi network via the web browser. The add-on provides a
 single-click installation and run solution for Home Assistant, allowing users
 to get their network up, running, and updated, easily.
 
-This add-on supports all Home Assistant supported architectures, including the
-Raspberry Pi.
+Since version 1.0.0 of this addon, only 64-bit architectures are supported.
 
 [:books: Read the full add-on documentation][docs]
 

--- a/README.md
+++ b/README.md
@@ -33,8 +33,6 @@ you to manage your UniFi network via the web browser. The add-on provides a
 single-click installation and run solution for Home Assistant, allowing users
 to get their network up, running, and updated, easily.
 
-Since version 1.0.0 of this addon, only 64-bit architectures are supported.
-
 [:books: Read the full add-on documentation][docs]
 
 ## Support

--- a/unifi/DOCS.md
+++ b/unifi/DOCS.md
@@ -5,9 +5,6 @@ you to manage your UniFi network via the web browser. The add-on provides a
 single-click installation and run solution for Home Assistant, allowing users
 to get their network up, running, and updated, easily.
 
-This add-on supports all Home Assistant supported architectures, including the
-Raspberry Pi.
-
 ## Installation
 
 The installation of this add-on is pretty straightforward and not different in


### PR DESCRIPTION
# Proposed Changes

I read https://github.com/hassio-addons/addon-unifi/issues/251 and I agree with @e28eta . While Raspberry Pi still is a supported platform, I think it is wrong to say that all architectures supported by Home Assistant are supported by this add-on. As far as I can see there are 3 architectures listed as not supported in the badge-list (armhf, armv7, i386).

I think just removing the line saying that all architectures are supported would be enough. I checked the [vscode add-on](https://github.com/hassio-addons/addon-vscode/) and there are no specifics mentioned there, so this will make this add-on similar.

Since the dropped 32-bit support is a recent change I suggest adding a line for that in the README, this might avoid some questions or opened issues. But of course this is totally up to you how you want it.

I just wanted to help out by suggestion an update to the documentation that I thought would improve it.

## Related Issues

fixes https://github.com/hassio-addons/addon-unifi/issues/251
