### PR TITLE
snapshot -> backup

### DIFF
--- a/unifi/config.json
+++ b/unifi/config.json
@@ -8,7 +8,7 @@
   "startup": "services",
   "arch": ["aarch64", "amd64"],
   "init": false,
-  "snapshot": "cold",
+  "backup": "cold",
   "map": ["backup:rw"],
   "ports": {
     "161/udp": null,


### PR DESCRIPTION
# Proposed Changes

Rename `snapshot` to `backup`.
See : https://developers.home-assistant.io/blog/2021/08/24/supervisor_update/

## Related Issues

Fixes #263 