### PR TITLE
⬆️ Upgrades add-on base image to 7.1.2

### DIFF
--- a/unifi/Dockerfile
+++ b/unifi/Dockerfile
@@ -1,4 +1,4 @@
-ARG BUILD_FROM=ghcr.io/hassio-addons/ubuntu-base/amd64:6.2.1
+ARG BUILD_FROM=ghcr.io/hassio-addons/ubuntu-base/amd64:7.1.2
 # hadolint ignore=DL3006
 FROM ${BUILD_FROM}
 
@@ -10,35 +10,20 @@ ARG BUILD_ARCH=amd64
 RUN \
     apt-get update \
     && apt-get install -y --no-install-recommends \
-        gnupg2=2.2.4-1ubuntu1.4 \
-    \
-    && curl -fsSL "https://www.mongodb.org/static/pgp/server-3.4.asc" \
-        | apt-key add -\
-    && echo "deb http://repo.mongodb.org/apt/ubuntu xenial/mongodb-org/3.4 multiverse" \
-        > /etc/apt/sources.list.d/mongodb.list \
-    \
-    && apt-get update \
-    && apt-get install -y --no-install-recommends \
-        binutils=2.30-21ubuntu1~18.04.7 \
+        binutils=2.34-6ubuntu1.3 \
         jsvc=1.0.15-8 \
-        libcap2=1:2.25-1.2 \
-        libssl1.0.0=1.0.2n-1ubuntu5.7 \
-        logrotate=3.11.0-0.1ubuntu1 \
-        mongodb-org-server=3.4.24 \
-        openjdk-8-jdk-headless=8u292-b10-0ubuntu1~18.04 \
+        libcap2=1:2.32-1 \
+        logrotate=3.14.0-4ubuntu3 \
+        mongodb-server=1:3.6.9+really3.6.8+90~g8e540c0b6d-0ubuntu5.3 \
+        openjdk-8-jdk-headless=8u292-b10-0ubuntu1~20.04 \
     \
     && curl -J -L -o /tmp/unifi.deb \
         "https://dl.ui.com/unifi/6.4.54/unifi_sysvinit_all.deb" \
     \
     && dpkg --install /tmp/unifi.deb \
-    \
-    && apt-get remove -y --purge \
-        gnupg2 \
-    \
     && apt-get clean \
     && rm -fr \
         /tmp/* \
-        /root/.gnupg \
         /var/{cache,log}/* \
         /var/lib/apt/lists/*
 

--- a/unifi/build.yaml
+++ b/unifi/build.yaml
@@ -1,4 +1,4 @@
 ---
 build_from:
-  aarch64: ghcr.io/hassio-addons/ubuntu-base/aarch64:6.2.1
-  amd64: ghcr.io/hassio-addons/ubuntu-base/amd64:6.2.1
+  aarch64: ghcr.io/hassio-addons/ubuntu-base/aarch64:7.1.2
+  amd64: ghcr.io/hassio-addons/ubuntu-base/amd64:7.1.2


### PR DESCRIPTION
# Proposed Changes

Upgrade the add-on base image to 7.1.2 (Ubuntu Focal).
This also switches to the MongoDB server to MongoDB 3.6, which is shipped with Ubuntu itself.
