### PR TITLE
Improve clarity about last log message

### DIFF
--- a/unifi/rootfs/etc/services.d/unifi/run
+++ b/unifi/rootfs/etc/services.d/unifi/run
@@ -7,7 +7,8 @@ declare -a options
 declare xmx
 declare xms
 
-bashio::log.info 'Starting the UniFi Network Application...'
+bashio::log.info 'Now starting the UniFi Network Application...'
+bashio::log.info 'Note: No add-on specific logs beyond this point.'
 
 xmx=256
 if bashio::config.has_value 'memory_max'; then


### PR DESCRIPTION
# Proposed Changes

Add a small tweak/additional log message to the start-up log, as users expect more to show up.
Unfortunately, UniFi doesn't log much more, so it seems "stuck", while you can't tell...
