### PR TITLE
⬆️ Update openjdk-8-jdk-headless to 8u312-b07-0ubuntu1~20.04

### DIFF
--- a/unifi/Dockerfile
+++ b/unifi/Dockerfile
@@ -15,7 +15,7 @@ RUN \
         libcap2=1:2.32-1 \
         logrotate=3.14.0-4ubuntu3 \
         mongodb-server=1:3.6.9+really3.6.8+90~g8e540c0b6d-0ubuntu5.3 \
-        openjdk-8-jdk-headless=8u292-b10-0ubuntu1~20.04 \
+        openjdk-8-jdk-headless=8u312-b07-0ubuntu1~20.04 \
     \
     && curl -J -L -o /tmp/unifi.deb \
         "https://dl.ui.com/unifi/6.5.55/unifi_sysvinit_all.deb" \


### PR DESCRIPTION
# Proposed Changes

Updating this dependency, since we can't build the image anymore because the previous version doesn't exist in the repository anymore.

Build logs before : 
```
21-12-19 19:32:14 INFO (SyncWorker_5) [supervisor.docker.interface] Removing image local/amd64-addon-unifi with latest and None
21-12-19 19:32:14 INFO (SyncWorker_2) [supervisor.docker.addon] Starting build for local/amd64-addon-unifi:dev
21-12-19 19:32:22 ERROR (SyncWorker_2) [supervisor.docker.addon] Can't build local/amd64-addon-unifi:dev: The command '/bin/bash -o pipefail -c apt-get update     && apt-get install -y --no-install-recommends         binutils=2.34-6ubuntu1.3         jsvc=1.0.15-8         libcap2=1:2.32-1         logrotate=3.14.0-4ubuntu3         mongodb-server=1:3.6.9+really3.6.8+90~g8e540c0b6d-0ubuntu5.3         openjdk-8-jdk-headless=8u292-b10-0ubuntu1~20.04         && curl -J -L -o /tmp/unifi.deb         "https://dl.ui.com/unifi/6.5.55/unifi_sysvinit_all.deb"         && dpkg --install /tmp/unifi.deb     && apt-get clean     && rm -fr         /tmp/*         /var/{cache,log}/*         /var/lib/apt/lists/*' returned a non-zero code: 100
21-12-19 19:32:22 ERROR (SyncWorker_2) [supervisor.docker.addon] Build log: 
Step 1/20 : ARG BUILD_FROM=ghcr.io/hassio-addons/ubuntu-base/amd64:7.1.3
Step 2/20 : FROM ${BUILD_FROM}
 ---> e9d8efb636e7
Step 3/20 : SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 ---> Using cache
 ---> 42fd933aef4f
Step 4/20 : ARG BUILD_ARCH=amd64
 ---> Using cache
 ---> 2f4c931c2ab2
Step 5/20 : RUN     apt-get update     && apt-get install -y --no-install-recommends         binutils=2.34-6ubuntu1.3         jsvc=1.0.15-8         libcap2=1:2.32-1         logrotate=3.14.0-4ubuntu3         mongodb-server=1:3.6.9+really3.6.8+90~g8e540c0b6d-0ubuntu5.3         openjdk-8-jdk-headless=8u292-b10-0ubuntu1~20.04         && curl -J -L -o /tmp/unifi.deb         "https://dl.ui.com/unifi/6.5.55/unifi_sysvinit_all.deb"         && dpkg --install /tmp/unifi.deb     && apt-get clean     && rm -fr         /tmp/*         /var/{cache,log}/*         /var/lib/apt/lists/*
 ---> Running in 6c8603e87ab9
Get:1 http://security.ubuntu.com/ubuntu focal-security InRelease [114 kB]
Get:2 http://archive.ubuntu.com/ubuntu focal InRelease [265 kB]
Get:3 http://security.ubuntu.com/ubuntu focal-security/main amd64 Packages [1335 kB]
Get:4 http://security.ubuntu.com/ubuntu focal-security/multiverse amd64 Packages [30.1 kB]
Get:5 http://security.ubuntu.com/ubuntu focal-security/universe amd64 Packages [828 kB]
Get:6 http://security.ubuntu.com/ubuntu focal-security/restricted amd64 Packages [733 kB]
Get:7 http://archive.ubuntu.com/ubuntu focal-updates InRelease [114 kB]
Get:8 http://archive.ubuntu.com/ubuntu focal-backports InRelease [108 kB]
Get:9 http://archive.ubuntu.com/ubuntu focal/main amd64 Packages [1275 kB]
Get:10 http://archive.ubuntu.com/ubuntu focal/restricted amd64 Packages [33.4 kB]
Get:11 http://archive.ubuntu.com/ubuntu focal/universe amd64 Packages [11.3 MB]
Get:12 http://archive.ubuntu.com/ubuntu focal/multiverse amd64 Packages [177 kB]
Get:13 http://archive.ubuntu.com/ubuntu focal-updates/main amd64 Packages [1758 kB]
Get:14 http://archive.ubuntu.com/ubuntu focal-updates/multiverse amd64 Packages [33.6 kB]
Get:15 http://archive.ubuntu.com/ubuntu focal-updates/restricted amd64 Packages [797 kB]
Get:16 http://archive.ubuntu.com/ubuntu focal-updates/universe amd64 Packages [1108 kB]
Get:17 http://archive.ubuntu.com/ubuntu focal-backports/universe amd64 Packages [21.7 kB]
Get:18 http://archive.ubuntu.com/ubuntu focal-backports/main amd64 Packages [50.8 kB]
Fetched 20.1 MB in 3s (7565 kB/s)
Reading package lists...
Reading package lists...
Building dependency tree...
Reading state information...
E: Version '8u292-b10-0ubuntu1~20.04' for 'openjdk-8-jdk-headless' was not found
```

## Related Issues


[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/
