### PR TITLE
⬆️ Upgrades UniFi Network Application to 7.1.65

### DIFF
--- a/unifi/Dockerfile
+++ b/unifi/Dockerfile
@@ -18,7 +18,7 @@ RUN \
         openjdk-8-jdk-headless=8u312-b07-0ubuntu1~20.04 \
     \
     && curl -J -L -o /tmp/unifi.deb \
-        "https://dl.ui.com/unifi/7.1.61/unifi_sysvinit_all.deb" \
+        "https://dl.ui.com/unifi/7.1.65/unifi_sysvinit_all.deb" \
     \
     && dpkg --install /tmp/unifi.deb \
     && apt-get clean \


### PR DESCRIPTION
The following fixes for UniFi Network Application since 7.1.61:

Bugfixes
    Fix memory leak affecting users using a self-hosted version of the Network application and using VPN features.
    Fix rare issue applying configuration on UXG Pro.
    Fix USW adoption issue due to a invalid IP subnet configuration for L3 Networks/Static Routes.
    Fix a rare issue where sometimes UXG-Pro adoption does not work.
    Fix various issues with creating/editing traffic rules/routes.

Known issues
    Image for the USG-Pro-4 in the dashboard is missing.

# Proposed Changes

> Upgrade .deb path for 7.1.65 now its released.
> [UniFi 7.1.65 Release Announcement](https://community.ui.com/releases/UniFi-Network-Application-7-1-65/)

## Related Issues

> ([Github link][autolink-references] to related issues or pull requests)

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/
