### PR TITLE
⬆️ Upgrades UniFi Network Application to 7.1.66

### DIFF
--- a/unifi/Dockerfile
+++ b/unifi/Dockerfile
@@ -18,7 +18,7 @@ RUN \
         openjdk-8-jdk-headless=8u312-b07-0ubuntu1~20.04 \
     \
     && curl -J -L -o /tmp/unifi.deb \
-        "https://dl.ui.com/unifi/7.1.65/unifi_sysvinit_all.deb" \
+        "https://dl.ui.com/unifi/7.1.66/unifi_sysvinit_all.deb" \
     \
     && dpkg --install /tmp/unifi.deb \
     && apt-get clean \


### PR DESCRIPTION
The following fixes for UniFi Network Application since 7.1.65:

**Improvements**
Improve application stability when using mobile apps.

**Known issues**
Image for the USG-Pro-4 in the dashboard is missing, fixed in 7.2.

# Proposed Changes
> Upgrade .deb path for 7.1.66 now its released.
> [UniFi 7.1.66 Release Announcement](https://community.ui.com/releases/UniFi-Network-Application-7-1-66/cf1208d2-3898-418c-b841-699e7b773fd4)

## Related Issues

> ([Github link][autolink-references] to related issues or pull requests)

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/
