### PR TITLE
:ambulance: Fix missing log folders causing crash

### DIFF
--- a/unifi/Dockerfile
+++ b/unifi/Dockerfile
@@ -23,8 +23,10 @@ RUN \
     && apt-get clean \
     && rm -fr \
         /tmp/* \
-        /var/{cache,log}/* \
-        /var/lib/apt/lists/*
+        /var/cache/* \
+        /var/lib/apt/lists/* \
+        /var/log/*.log \
+        /var/log/apt
 
 # Copy root filesystem
 COPY rootfs /


### PR DESCRIPTION
# Proposed Changes

It seems that newer UniFi Network Application versions require the log folder to exist (or the application gets into a limbo state, serving only 404s or getting stuck in database migration).

This PR adjusts the cleanup in our Dockerfile to be less aggressive (and keeps the folders around).
