### PR TITLE
Fix markdown formatting in documentation

### DIFF
--- a/unifi/DOCS.md
+++ b/unifi/DOCS.md
@@ -109,6 +109,7 @@ you can manually adopt a device by following these steps:
     INFO: I/O exception (java.net.ConnectException) caught when processing
     request: Connection refused (Connection refused)
   ```
+
   This is a known issue, however, the add-on functions normally.
 
 - Due to security policies in the UniFi Network Application software, it is

--- a/unifi/DOCS.md
+++ b/unifi/DOCS.md
@@ -107,9 +107,9 @@ you can manually adopt a device by following these steps:
 
   ```
     INFO: I/O exception (java.net.ConnectException) caught when processing
-    request: Connection refused (Connection refused)`. This is a known issue,
-    however, the add-on functions normally.
+    request: Connection refused (Connection refused)
   ```
+  This is a known issue, however, the add-on functions normally.
 
 - Due to security policies in the UniFi Network Application software, it is
   currently impossible to add the UniFI web interface to your Home Assistant


### PR DESCRIPTION
# Proposed Changes

I was reading the doc and found some incorrect markdown formatting. It appears this was a copy-paste error from the `README.md` which used to contain a similar text.

Just a small fix for the formatting :)
