### PR TITLE
Update Network controller to version 8.0.28

### DIFF
--- a/unifi/Dockerfile
+++ b/unifi/Dockerfile
@@ -17,7 +17,7 @@ RUN \
         openjdk-17-jdk-headless=17* \
     \
     && curl -J -L -o /tmp/unifi.deb \
-        "https://dl.ui.com/unifi/8.0.28-66495b8e3a/unifi_sysvinit_all.deb" \
+        "https://dl.ui.com/unifi/8.0.28/unifi_sysvinit_all.deb" \
     \
     && dpkg --install /tmp/unifi.deb \
     && apt-get clean \

--- a/unifi/Dockerfile
+++ b/unifi/Dockerfile
@@ -9,15 +9,15 @@ SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 RUN \
     apt-get update \
     && apt-get install -y --no-install-recommends \
-        binutils=2.34-6ubuntu1.7 \
+        binutils=2.34-6ubuntu1.8 \
         jsvc=1.0.15-8 \
-        libcap2=1:2.32-1 \
+        libcap2=1:2.32-1ubuntu0.1 \
         logrotate=3.14.0-4ubuntu3 \
         mongodb-server=1:3.6.9+really3.6.8+90~g8e540c0b6d-0ubuntu5.3 \
         openjdk-17-jdk-headless=17* \
     \
     && curl -J -L -o /tmp/unifi.deb \
-        "https://dl.ui.com/unifi/8.0.26/unifi_sysvinit_all.deb" \
+        "https://dl.ui.com/unifi/8.0.28-66495b8e3a/unifi_sysvinit_all.deb" \
     \
     && dpkg --install /tmp/unifi.deb \
     && apt-get clean \


### PR DESCRIPTION
Updating controller to released version 8.0.28 on 25th Jan 2024.

# Proposed Changes

New Network controller version released on 25th Jan 2024.

## Related Issues

> ([Github link][autolink-references] to related issues or pull requests)

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/
