### PR TITLE
Update base image to ubuntu-base:9.0.4

### DIFF
--- a/unifi/Dockerfile
+++ b/unifi/Dockerfile
@@ -13,9 +13,12 @@ RUN \
         binutils=2.34-6ubuntu1.9 \
         libcap2=1:2.32-1ubuntu0.1 \
         logrotate=3.14.0-4ubuntu3 \
-        mongodb-server=1:3.6.9+really3.6.8+90~g8e540c0b6d-0ubuntu5.3 \
         openjdk-17-jre-headless=17* \
     \
+    && curl -J -L -o /usr/share/keyrings/mongodb-server-4.4.gpg https://pgp.mongodb.com/server-4.4.pub \
+    && echo "deb [ arch=amd64,arm64 signed-by=/usr/share/keyrings/mongodb-server-4.4.gpg ] https://repo.mongodb.org/apt/ubuntu focal/mongodb-org/4.4 multiverse" >/etc/apt/sources.list.d/mongodb-org-4.4.list \
+    && apt-get update \
+    && apt-get install -y --no-install-recommends mongodb-org-server=4.4.29 \
     && curl -J -L -o /tmp/unifi.deb \
         "https://dl.ui.com/unifi/8.0.28/unifi_sysvinit_all.deb" \
     \

--- a/unifi/Dockerfile
+++ b/unifi/Dockerfile
@@ -3,6 +3,7 @@ ARG BUILD_FROM=ghcr.io/hassio-addons/ubuntu-base:9.0.4
 FROM ${BUILD_FROM}
 
 # Set shell
+ARG BUILD_ARCH=amd64
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
 # Setup base system
@@ -14,14 +15,19 @@ RUN \
         logrotate=3.19.0-1ubuntu1.1 \
         openjdk-17-jre-headless=17* \
     \
-    && curl -J -L -o /usr/share/keyrings/mongodb-server-7.0.gpg https://pgp.mongodb.com/server-7.0.pub \
-    && echo "deb [ arch=amd64,arm64 signed-by=/usr/share/keyrings/mongodb-server-7.0.gpg ] https://repo.mongodb.org/apt/ubuntu jammy/mongodb-org/7.0 multiverse" >/etc/apt/sources.list.d/mongodb-org-7.0.list \
+    && pkgname=libssl1.1_1.1.1f-1ubuntu2.22 \
+    && if [ "${BUILD_ARCH}" = "aarch64" ]; then pkgurl="http://ports.ubuntu.com/pool/main/o/openssl/${pkgname}_arm64.deb"; fi \
+    && if [ "${BUILD_ARCH}" = "amd64" ]; then pkgurl="http://security.ubuntu.com/ubuntu/pool/main/o/openssl/${pkgname}_amd64.deb"; fi \
+    && curl -L -o /tmp/libssl.deb "${pkgurl}" \
+    && dpkg --install "/tmp/libssl.deb" \
+    && curl -J -L -o /etc/apt/keyrings/mongodb-server-4.4.gpg https://pgp.mongodb.com/server-4.4.pub \
+    && echo "deb [ arch=amd64,arm64 signed-by=/etc/apt/keyrings/mongodb-server-4.4.gpg ] https://repo.mongodb.org/apt/ubuntu focal/mongodb-org/4.4 multiverse" >/etc/apt/sources.list.d/mongodb-org-4.4.list \
     && apt-get update \
-    && apt-get install -y --no-install-recommends mongodb-org-server=7.0.7 \
+    && apt-get install -y --no-install-recommends mongodb-org-server=4.4.29 \
     && curl -J -L -o /tmp/unifi.deb \
         "https://dl.ui.com/unifi/8.0.28/unifi_sysvinit_all.deb" \
     \
-    && dpkg --install --ignore-depends=mongodb-org-server /tmp/unifi.deb \
+    && dpkg --install /tmp/unifi.deb \
     && apt-get clean \
     && rm -fr \
         /tmp/* \
@@ -38,7 +44,6 @@ HEALTHCHECK --start-period=5m \
     CMD curl --insecure --fail https://localhost:8443 || exit 1
 
 # Build arguments
-ARG BUILD_ARCH
 ARG BUILD_DATE
 ARG BUILD_DESCRIPTION
 ARG BUILD_NAME

--- a/unifi/Dockerfile
+++ b/unifi/Dockerfile
@@ -1,4 +1,4 @@
-ARG BUILD_FROM=ghcr.io/hassio-addons/ubuntu-base:8.2.0
+ARG BUILD_FROM=ghcr.io/hassio-addons/ubuntu-base:9.0.4
 # hadolint ignore=DL3006
 FROM ${BUILD_FROM}
 
@@ -10,19 +10,18 @@ RUN \
     apt-get update \
     && apt-get upgrade -y \
     && apt-get install -y --no-install-recommends \
-        binutils=2.34-6ubuntu1.9 \
-        libcap2=1:2.32-1ubuntu0.1 \
-        logrotate=3.14.0-4ubuntu3 \
+        binutils=2.38-4ubuntu2.6 \
+        logrotate=3.19.0-1ubuntu1.1 \
         openjdk-17-jre-headless=17* \
     \
-    && curl -J -L -o /usr/share/keyrings/mongodb-server-4.4.gpg https://pgp.mongodb.com/server-4.4.pub \
-    && echo "deb [ arch=amd64,arm64 signed-by=/usr/share/keyrings/mongodb-server-4.4.gpg ] https://repo.mongodb.org/apt/ubuntu focal/mongodb-org/4.4 multiverse" >/etc/apt/sources.list.d/mongodb-org-4.4.list \
+    && curl -J -L -o /usr/share/keyrings/mongodb-server-7.0.gpg https://pgp.mongodb.com/server-7.0.pub \
+    && echo "deb [ arch=amd64,arm64 signed-by=/usr/share/keyrings/mongodb-server-7.0.gpg ] https://repo.mongodb.org/apt/ubuntu jammy/mongodb-org/7.0 multiverse" >/etc/apt/sources.list.d/mongodb-org-7.0.list \
     && apt-get update \
-    && apt-get install -y --no-install-recommends mongodb-org-server=4.4.29 \
+    && apt-get install -y --no-install-recommends mongodb-org-server=7.0.7 \
     && curl -J -L -o /tmp/unifi.deb \
         "https://dl.ui.com/unifi/8.0.28/unifi_sysvinit_all.deb" \
     \
-    && dpkg --install /tmp/unifi.deb \
+    && dpkg --install --ignore-depends=mongodb-org-server /tmp/unifi.deb \
     && apt-get clean \
     && rm -fr \
         /tmp/* \

--- a/unifi/Dockerfile
+++ b/unifi/Dockerfile
@@ -10,7 +10,7 @@ RUN \
     apt-get update \
     && apt-get upgrade -y \
     && apt-get install -y --no-install-recommends \
-        binutils=2.34-6ubuntu1.8 \
+        binutils=2.34-6ubuntu1.9 \
         libcap2=1:2.32-1ubuntu0.1 \
         logrotate=3.14.0-4ubuntu3 \
         mongodb-server=1:3.6.9+really3.6.8+90~g8e540c0b6d-0ubuntu5.3 \

--- a/unifi/build.yaml
+++ b/unifi/build.yaml
@@ -1,7 +1,7 @@
 ---
 build_from:
-  aarch64: ghcr.io/hassio-addons/ubuntu-base:8.2.0
-  amd64: ghcr.io/hassio-addons/ubuntu-base:8.2.0
+  aarch64: ghcr.io/hassio-addons/ubuntu-base:9.0.4
+  amd64: ghcr.io/hassio-addons/ubuntu-base:9.0.4
 codenotary:
   base_image: codenotary@frenck.dev
   signer: codenotary@frenck.dev

--- a/unifi/rootfs/etc/s6-overlay/s6-rc.d/init-unifi/run
+++ b/unifi/rootfs/etc/s6-overlay/s6-rc.d/init-unifi/run
@@ -20,16 +20,16 @@ fi
 rm -fr /usr/lib/unifi/data/backup
 ln -s /backup/unifi /usr/lib/unifi/data/backup
 
-# Enable small files on MongoDB
-if ! bashio::fs.file_exists "${properties}"; then
-    touch "${properties}"
-    echo "unifi.db.extraargs=--smallfiles" > "${properties}"
-fi
-
-#shellcheck disable=SC2016
+# Remove --smallfiles argument from properties file, it's no longer present in mongoDB >= 4.2
+# https://www.mongodb.com/docs/v4.2/reference/configuration-options/#removed-mmapv1-options
+if bashio::fs.file_exists "${properties}"; then
 sed -i \
-    '/^unifi.db.extraargs=/{h;s/=.*/=--smallfiles/};${x;/^$/{s//unifi.db.extraargs=--smallfiles/;H};x}' \
+    's/^\(unifi.db.extraargs=.*\)--smallfiles/\1/' \
     "${properties}"
+sed -i \
+    '/^unifi.db.extraargs= *$/d' \
+    "${properties}"
+fi
 
 # If there is no keystore yet, we are good to go
 if ! bashio::fs.file_exists "${KEYSTORE}"; then


### PR DESCRIPTION
# Proposed Changes

This switches from ubuntu-base:8 to ubuntu-base:9 as the base image (ie ubuntu 20.04 to ubuntu 22.04).

The main complication is mongodb, it's now installed from mongodb community servers as it's gone from newer ubuntu repositories. Beware of the licence change, previously the addon used mongodb version 3.6.9 released under the AGPL, while 4.0.3 and newer are released under the non-free SSPL
https://en.wikipedia.org/wiki/MongoDB#Licensing

Installing mongodb 4.4 which is compatible with the unifi package requires some hackish install of the appropriate libssl.
mongodb 7.0 is easier to install, but requires the use of `--ignore-depends=mongodb-org-server` when installing the unifi package.

I couldn't make my mind regarding which option is best, so it's easy to pick one or the other by keeping/removing the last commit in this PR.