### PR TITLE
Pin binutils to 2.34-6ubuntu1.9

### DIFF
--- a/unifi/Dockerfile
+++ b/unifi/Dockerfile
@@ -10,7 +10,7 @@ RUN \
     apt-get update \
     && apt-get upgrade -y \
     && apt-get install -y --no-install-recommends \
-        binutils=2.34-6ubuntu1.8 \
+        binutils=2.34-6ubuntu1.9 \
         libcap2=1:2.32-1ubuntu0.1 \
         logrotate=3.14.0-4ubuntu3 \
         mongodb-server=1:3.6.9+really3.6.8+90~g8e540c0b6d-0ubuntu5.3 \


### PR DESCRIPTION
# Proposed Changes

Pinning binutils from 2.34-6ubuntu1.8 to 2.34-6ubuntu1.9.

## Related Issues

> ([Github link][autolink-references] to related issues or pull requests)

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/
