### PR TITLE
Revert "Update base image to ubuntu-base:9.0.4"

### DIFF
--- a/unifi/Dockerfile
+++ b/unifi/Dockerfile
@@ -1,9 +1,8 @@
-ARG BUILD_FROM=ghcr.io/hassio-addons/ubuntu-base:9.0.4
+ARG BUILD_FROM=ghcr.io/hassio-addons/ubuntu-base:8.2.0
 # hadolint ignore=DL3006
 FROM ${BUILD_FROM}
 
 # Set shell
-ARG BUILD_ARCH=amd64
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
 # Setup base system
@@ -11,19 +10,12 @@ RUN \
     apt-get update \
     && apt-get upgrade -y \
     && apt-get install -y --no-install-recommends \
-        binutils=2.38-4ubuntu2.6 \
-        logrotate=3.19.0-1ubuntu1.1 \
+        binutils=2.34-6ubuntu1.8 \
+        libcap2=1:2.32-1ubuntu0.1 \
+        logrotate=3.14.0-4ubuntu3 \
+        mongodb-server=1:3.6.9+really3.6.8+90~g8e540c0b6d-0ubuntu5.3 \
         openjdk-17-jre-headless=17* \
     \
-    && pkgname=libssl1.1_1.1.1f-1ubuntu2.22 \
-    && if [ "${BUILD_ARCH}" = "aarch64" ]; then pkgurl="http://ports.ubuntu.com/pool/main/o/openssl/${pkgname}_arm64.deb"; fi \
-    && if [ "${BUILD_ARCH}" = "amd64" ]; then pkgurl="http://security.ubuntu.com/ubuntu/pool/main/o/openssl/${pkgname}_amd64.deb"; fi \
-    && curl -L -o /tmp/libssl.deb "${pkgurl}" \
-    && dpkg --install "/tmp/libssl.deb" \
-    && curl -J -L -o /etc/apt/keyrings/mongodb-server-4.4.gpg https://pgp.mongodb.com/server-4.4.pub \
-    && echo "deb [ arch=amd64,arm64 signed-by=/etc/apt/keyrings/mongodb-server-4.4.gpg ] https://repo.mongodb.org/apt/ubuntu focal/mongodb-org/4.4 multiverse" >/etc/apt/sources.list.d/mongodb-org-4.4.list \
-    && apt-get update \
-    && apt-get install -y --no-install-recommends mongodb-org-server=4.4.29 \
     && curl -J -L -o /tmp/unifi.deb \
         "https://dl.ui.com/unifi/8.1.113/unifi_sysvinit_all.deb" \
     \
@@ -44,6 +36,7 @@ HEALTHCHECK --start-period=5m \
     CMD curl --insecure --fail https://localhost:8443 || exit 1
 
 # Build arguments
+ARG BUILD_ARCH
 ARG BUILD_DATE
 ARG BUILD_DESCRIPTION
 ARG BUILD_NAME

--- a/unifi/build.yaml
+++ b/unifi/build.yaml
@@ -1,7 +1,7 @@
 ---
 build_from:
-  aarch64: ghcr.io/hassio-addons/ubuntu-base:9.0.4
-  amd64: ghcr.io/hassio-addons/ubuntu-base:9.0.4
+  aarch64: ghcr.io/hassio-addons/ubuntu-base:8.2.0
+  amd64: ghcr.io/hassio-addons/ubuntu-base:8.2.0
 codenotary:
   base_image: codenotary@frenck.dev
   signer: codenotary@frenck.dev

--- a/unifi/rootfs/etc/s6-overlay/s6-rc.d/init-unifi/run
+++ b/unifi/rootfs/etc/s6-overlay/s6-rc.d/init-unifi/run
@@ -20,16 +20,16 @@ fi
 rm -fr /usr/lib/unifi/data/backup
 ln -s /backup/unifi /usr/lib/unifi/data/backup
 
-# Remove --smallfiles argument from properties file, it's no longer present in mongoDB >= 4.2
-# https://www.mongodb.com/docs/v4.2/reference/configuration-options/#removed-mmapv1-options
-if bashio::fs.file_exists "${properties}"; then
-sed -i \
-    's/^\(unifi.db.extraargs=.*\)--smallfiles/\1/' \
-    "${properties}"
-sed -i \
-    '/^unifi.db.extraargs= *$/d' \
-    "${properties}"
+# Enable small files on MongoDB
+if ! bashio::fs.file_exists "${properties}"; then
+    touch "${properties}"
+    echo "unifi.db.extraargs=--smallfiles" > "${properties}"
 fi
+
+#shellcheck disable=SC2016
+sed -i \
+    '/^unifi.db.extraargs=/{h;s/=.*/=--smallfiles/};${x;/^$/{s//unifi.db.extraargs=--smallfiles/;H};x}' \
+    "${properties}"
 
 # If there is no keystore yet, we are good to go
 if ! bashio::fs.file_exists "${KEYSTORE}"; then


### PR DESCRIPTION
Reverts hassio-addons/addon-unifi#491

As this breaks existing installations. The new MongoDB version removes the deprecated mmap engine, and makes WiredTiger the new default. However, the PR listed, doesn't take that into account (no migration).

This shipping this, would break the add-on.

/CC @cfergeau