### PR TITLE
Bumping Network Application to 8.1.127

### DIFF
--- a/unifi/Dockerfile
+++ b/unifi/Dockerfile
@@ -17,7 +17,7 @@ RUN \
         openjdk-17-jre-headless=17* \
     \
     && curl -J -L -o /tmp/unifi.deb \
-        "https://dl.ui.com/unifi/8.1.113/unifi_sysvinit_all.deb" \
+        "https://dl.ui.com/unifi/8.1.127/unifi_sysvinit_all.deb" \
     \
     && dpkg --install /tmp/unifi.deb \
     && apt-get clean \


### PR DESCRIPTION
113 --> 127

# Proposed Changes

> UniFi Network Application 8.1.127 enhances Firewall Rules visibility and adds tunnel IP addresses and OSPF dynamic routing support for IPsec Site-to-Site VPNs.
> https://community.ui.com/releases/UniFi-Network-Application-8-1-127/571d2218-216c-4769-a292-796cff379561

## Related Issues

> ([Github link][autolink-references] to related issues or pull requests)

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/
