### PR TITLE
⬆️ Upgrades UniFi Network Application to 8.6.3

### DIFF
--- a/unifi/Dockerfile
+++ b/unifi/Dockerfile
@@ -17,7 +17,7 @@ RUN \
         openjdk-17-jre-headless=17* \
     \
     && curl -J -L -o /tmp/unifi.deb \
-        "https://dl.ui.com/unifi/8.5.6/unifi_sysvinit_all.deb" \
+        "https://dl.ui.com/unifi/8.6.3/unifi_sysvinit_all.deb" \
     \
     && dpkg --install /tmp/unifi.deb \
     && apt-get clean \


### PR DESCRIPTION
**Note:** This version is still in "Early Access", not yet ready to merge.

Release Notes: https://community.ui.com/releases/UniFi-Network-Application-8-6-3/4045c6bf-4059-4fdf-ac19-2502c526103f