### PR TITLE
Update Unifi to 8.6.9 (do not merge: early access)

### DIFF
--- a/unifi/Dockerfile
+++ b/unifi/Dockerfile
@@ -17,7 +17,7 @@ RUN \
         openjdk-17-jre-headless=17* \
     \
     && curl -J -L -o /tmp/unifi.deb \
-        "https://dl.ui.com/unifi/8.5.6/unifi_sysvinit_all.deb" \
+        "https://dl.ui.com/unifi/8.6.9/unifi_sysvinit_all.deb" \
     \
     && dpkg --install /tmp/unifi.deb \
     && apt-get clean \


### PR DESCRIPTION
# Proposed Changes

> (Describe the changes and rationale behind them)

New version of Unifi is available.
https://community.ui.com/releases/UniFi-Network-Application-8-6-9/e4bd3f71-a2c4-4c98-b12a-a8b0b1c2178e

On a second look I'm realizing that this version is in Early Access.

Ubiquity support has requested I install it to enable a new feature to resolve an intermittent failure issue I'm having at the moment. 

Is there a way for me to update to this locally on HAOS without having to self host it separately manually?

## Related Issues

> ([Github link][autolink-references] to related issues or pull requests)

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/
