### PR TITLE
Bump Unifi Network Server to 8.6.9

### DIFF
--- a/unifi/Dockerfile
+++ b/unifi/Dockerfile
@@ -17,7 +17,7 @@ RUN \
         openjdk-17-jre-headless=17* \
     \
     && curl -J -L -o /tmp/unifi.deb \
-        "https://dl.ui.com/unifi/8.5.6/unifi_sysvinit_all.deb" \
+        "https://dl.ui.com/unifi/8.6.9/unifi_sysvinit_all.deb" \
     \
     && dpkg --install /tmp/unifi.deb \
     && apt-get clean \


### PR DESCRIPTION
Latest released version :https://www.ui.com/download/releases/network-server

# Proposed Changes

Upgrading Dockerfile to take latest version of the released Unifi Network Server.

## Related Issues

> ([Github link][autolink-references] to related issues or pull requests)

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/
