### PR TITLE
⬆️ Upgrades UniFi Network Application to 9.0.108

### DIFF
--- a/unifi/Dockerfile
+++ b/unifi/Dockerfile
@@ -17,7 +17,7 @@ RUN \
         openjdk-17-jre-headless=17* \
     \
     && curl -J -L -o /tmp/unifi.deb \
-        "https://dl.ui.com/unifi/8.6.9/unifi_sysvinit_all.deb" \
+        "https://dl.ui.com/unifi/9.0.108/unifi_sysvinit_all.deb" \
     \
     && dpkg --install /tmp/unifi.deb \
     && apt-get clean \


### PR DESCRIPTION
Rel notes: https://community.ui.com/releases/UniFi-Network-Application-9-0-108/248de26a-ad59-4d01-b8eb-33556fa9683b

https://community.ui.com/releases/r/network/9.0.108

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated Unifi software version from 8.6.9 to 9.0.108 in the Dockerfile
	- Routine version upgrade of Unifi package

<!-- end of auto-generated comment: release notes by coderabbit.ai -->