### PR TITLE
Update unifi network application to 9.0.108

### DIFF
--- a/unifi/Dockerfile
+++ b/unifi/Dockerfile
@@ -17,7 +17,7 @@ RUN \
         openjdk-17-jre-headless=17* \
     \
     && curl -J -L -o /tmp/unifi.deb \
-        "https://dl.ui.com/unifi/8.6.9/unifi_sysvinit_all.deb" \
+        "https://dl.ui.com/unifi/9.0.108/unifi_sysvinit_all.deb" \
     \
     && dpkg --install /tmp/unifi.deb \
     && apt-get clean \


### PR DESCRIPTION
# Proposed Changes

Update Unifi Network Application to 9.0.108

Release notes: https://community.ui.com/releases/r/network/9.0.108

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated UniFi software to version 9.0.108

<!-- end of auto-generated comment: release notes by coderabbit.ai -->