### PR TITLE
Bump libraries to latest version

### DIFF
--- a/unifi/Dockerfile
+++ b/unifi/Dockerfile
@@ -17,7 +17,7 @@ RUN \
         openjdk-17-jre-headless=17* \
     \
     && curl -J -L -o /tmp/unifi.deb \
-        "https://dl.ui.com/unifi/9.1.120/unifi_sysvinit_all.deb" \
+        "https://dl.ui.com/unifi/9.0.114/unifi_sysvinit_all.deb" \
     \
     && dpkg --install /tmp/unifi.deb \
     && apt-get clean \

--- a/unifi/Dockerfile
+++ b/unifi/Dockerfile
@@ -11,7 +11,7 @@ RUN \
     && apt-get upgrade -y \
     && apt-get install -y --no-install-recommends \
         binutils=2.34-6ubuntu1.11 \
-        libcap2=1:2.32-1ubuntu0.1 \
+        libcap2=1:2.32-1ubuntu0.2 \
         logrotate=3.14.0-4ubuntu3 \
         mongodb-server=1:3.6.9+really3.6.8+90~g8e540c0b6d-0ubuntu5.3 \
         openjdk-17-jre-headless=17* \

--- a/unifi/Dockerfile
+++ b/unifi/Dockerfile
@@ -10,7 +10,7 @@ RUN \
     apt-get update \
     && apt-get upgrade -y \
     && apt-get install -y --no-install-recommends \
-        binutils=2.34-6ubuntu1.9 \
+        binutils=2.34-6ubuntu1.11 \
         libcap2=1:2.32-1ubuntu0.1 \
         logrotate=3.14.0-4ubuntu3 \
         mongodb-server=1:3.6.9+really3.6.8+90~g8e540c0b6d-0ubuntu5.3 \

--- a/unifi/Dockerfile
+++ b/unifi/Dockerfile
@@ -17,7 +17,7 @@ RUN \
         openjdk-17-jre-headless=17* \
     \
     && curl -J -L -o /tmp/unifi.deb \
-        "https://dl.ui.com/unifi/9.1.119/unifi_sysvinit_all.deb" \
+        "https://dl.ui.com/unifi/9.0.114/unifi_sysvinit_all.deb" \
     \
     && dpkg --install /tmp/unifi.deb \
     && apt-get clean \

--- a/unifi/Dockerfile
+++ b/unifi/Dockerfile
@@ -17,7 +17,7 @@ RUN \
         openjdk-17-jre-headless=17* \
     \
     && curl -J -L -o /tmp/unifi.deb \
-        "https://dl.ui.com/unifi/9.0.114/unifi_sysvinit_all.deb" \
+        "https://dl.ui.com/unifi/9.1.119/unifi_sysvinit_all.deb" \
     \
     && dpkg --install /tmp/unifi.deb \
     && apt-get clean \

--- a/unifi/Dockerfile
+++ b/unifi/Dockerfile
@@ -17,7 +17,7 @@ RUN \
         openjdk-17-jre-headless=17* \
     \
     && curl -J -L -o /tmp/unifi.deb \
-        "https://dl.ui.com/unifi/9.0.114/unifi_sysvinit_all.deb" \
+        "https://dl.ui.com/unifi/9.1.120/unifi_sysvinit_all.deb" \
     \
     && dpkg --install /tmp/unifi.deb \
     && apt-get clean \


### PR DESCRIPTION
Updating libraries libcap2 and binutils to latest version.

# Proposed Changes



## Related Issues

> ([Github link][autolink-references] to related issues or pull requests)

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


## Summary by CodeRabbit

- **Chores**
  - Upgraded system packages for improved stability and security.
  - Applied minor package updates to enhance system reliability.
  - Updated Unifi package to a newer version for improved performance.
  - Updated system components to newer patch versions for better security.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->