### PR TITLE
⬆️ Upgrades UniFi Network Application to 9.1.120

### DIFF
--- a/unifi/Dockerfile
+++ b/unifi/Dockerfile
@@ -17,7 +17,7 @@ RUN \
         openjdk-17-jre-headless=17* \
     \
     && curl -J -L -o /tmp/unifi.deb \
-        "https://dl.ui.com/unifi/9.0.114/unifi_sysvinit_all.deb" \
+        "https://dl.ui.com/unifi/9.1.120/unifi_sysvinit_all.deb" \
     \
     && dpkg --install /tmp/unifi.deb \
     && apt-get clean \


### PR DESCRIPTION
# Proposed Changes

Bump version to 9.1.120 (released 25 April)

## Related Issues

https://www.ui.com/download/releases/network-server

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/
