### PR TITLE
⬆️ Upgrades UniFi Network Application to 9.2.87

### DIFF
--- a/unifi/Dockerfile
+++ b/unifi/Dockerfile
@@ -17,7 +17,7 @@ RUN \
         openjdk-17-jre-headless=17* \
     \
     && curl -J -L -o /tmp/unifi.deb \
-        "https://dl.ui.com/unifi/9.1.120/unifi_sysvinit_all.deb" \
+        "https://dl.ui.com/unifi/9.2.87/unifi_sysvinit_all.deb" \
     \
     && dpkg --install /tmp/unifi.deb \
     && apt-get clean \


### PR DESCRIPTION
Release notes: https://community.ui.com/releases/UniFi-Network-Application-9-2-87/81a6a594-e925-4100-b1d7-351d2b91a7fd

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the UniFi package to version 9.2.87 in the installation process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->