### PR TITLE
⬆️ Upgrades UniFi Network Application to 9.3.45

### DIFF
--- a/unifi/Dockerfile
+++ b/unifi/Dockerfile
@@ -17,7 +17,7 @@ RUN \
         openjdk-17-jre-headless=17* \
     \
     && curl -J -L -o /tmp/unifi.deb \
-        "https://dl.ui.com/unifi/9.3.43/unifi_sysvinit_all.deb" \
+        "https://dl.ui.com/unifi/9.3.45/unifi_sysvinit_all.deb" \
     \
     && dpkg --install /tmp/unifi.deb \
     && apt-get clean \


### PR DESCRIPTION
# Proposed Changes

Bump Unifi Network Application to 9.3.45

## Related Issues

> ([Github link][autolink-references] to related issues or pull requests)

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the UniFi software package to version 9.3.45 in the Docker image.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->