### PR TITLE
Update documentation to right place for Host override.

### DIFF
--- a/unifi/DOCS.md
+++ b/unifi/DOCS.md
@@ -20,11 +20,9 @@ comparison to installing any other Home Assistant add-on.
    well.
 1. Click the "OPEN WEB UI" button, and follow the initial wizard.
 1. After completing the wizard, log in with the credentials just created.
-1. Go to the settings (gears icon in the bottom left) -> System ->
-   Advanced.
-1. Next to the `Inform Host` label, click the checkbox option for `Override` so that is now "checked".
-1. Change the `Host for Inform` to match the IP or hostname of
-   the device running Home Assistant.
+1. Select Unifi Devices which you can find on the left hand. Once there, select Device Updates and Settings on the top right.
+1. Scroll down to Device settings and below the `Inform Host Override` label, enter the IP or hostname of the device running Home Assistant.
+1. Click the checkbox option for `Inform Host Override` so that is now "checked".
 1. Hit the "Apply Changes" button to activate the settings.
 1. Ready to go!
 


### PR DESCRIPTION
# Proposed Changes

Adapted the documentation to the new location for host override as this has been changed in some of the latest versions, so documentation is not up-to-date.

## Related Issues

fixes https://github.com/hassio-addons/addon-unifi/issues/582

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated installation instructions to reflect the new UniFi interface flow for configuring Inform Host Override.
  * Clarifies where to enter the IP/hostname, to enable the override checkbox, and to apply changes.
  * Aligns terminology to “Inform Host Override” for consistency.
  * Improves guidance while keeping the remaining steps unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->