### PR TITLE
⬆️ Upgrades UniFi Network Application to 10.1.83

### DIFF
--- a/unifi/Dockerfile
+++ b/unifi/Dockerfile
@@ -2,40 +2,49 @@ ARG BUILD_FROM=ghcr.io/hassio-addons/ubuntu-base:8.2.0
 # hadolint ignore=DL3006
 FROM ${BUILD_FROM}
 
-# Set shell
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
-# Setup base system
 RUN \
     apt-get update \
     && apt-get upgrade -y \
     && apt-get install -y --no-install-recommends \
+        ca-certificates \
+        curl \
+        gnupg \
+        apt-transport-https \
         binutils=2.34-6ubuntu1.11 \
         libcap2=1:2.32-1ubuntu0.2 \
         logrotate=3.14.0-4ubuntu3 \
         mongodb-server=1:3.6.9+really3.6.8+90~g8e540c0b6d-0ubuntu5.3 \
-        openjdk-17-jre-headless=17* \
     \
+    # Add Adoptium (Temurin) repo for Java 25
+    && curl -fsSL https://packages.adoptium.net/artifactory/api/gpg/key/public \
+        | gpg --dearmor -o /usr/share/keyrings/adoptium.gpg \
+    && echo "deb [signed-by=/usr/share/keyrings/adoptium.gpg] https://packages.adoptium.net/artifactory/deb jammy main" \
+        > /etc/apt/sources.list.d/adoptium.list \
+    && apt-get update \
+    && apt-get install -y --no-install-recommends \
+        temurin-25-jre \
+    \
+    # Install UniFi 10.1
     && curl -J -L -o /tmp/unifi.deb \
-        "https://dl.ui.com/unifi/10.0.162/unifi_sysvinit_all.deb" \
-    \
+        "https://dl.ui.com/unifi/10.1.83/unifi_sysvinit_all.deb" \
     && dpkg --install /tmp/unifi.deb \
+    && apt-get -f install -y \
+    \
     && apt-get clean \
-    && rm -fr \
+    && rm -rf \
         /tmp/* \
         /var/cache/* \
         /var/lib/apt/lists/* \
         /var/log/*.log \
         /var/log/apt
 
-# Copy root filesystem
 COPY rootfs /
 
-# Health check
 HEALTHCHECK --start-period=5m \
     CMD curl --insecure --fail https://localhost:8443 || exit 1
 
-# Build arguments
 ARG BUILD_ARCH
 ARG BUILD_DATE
 ARG BUILD_DESCRIPTION
@@ -44,7 +53,6 @@ ARG BUILD_REF
 ARG BUILD_REPOSITORY
 ARG BUILD_VERSION
 
-# Labels
 LABEL \
     io.hass.name="${BUILD_NAME}" \
     io.hass.description="${BUILD_DESCRIPTION}" \

--- a/unifi/Dockerfile
+++ b/unifi/Dockerfile
@@ -2,8 +2,10 @@ ARG BUILD_FROM=ghcr.io/hassio-addons/ubuntu-base:8.2.0
 # hadolint ignore=DL3006
 FROM ${BUILD_FROM}
 
+# Set shell
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
+# Setup base system
 RUN \
     apt-get update \
     && apt-get upgrade -y \
@@ -26,25 +28,27 @@ RUN \
     && apt-get install -y --no-install-recommends \
         temurin-25-jre \
     \
-    # Install UniFi 10.1
     && curl -J -L -o /tmp/unifi.deb \
         "https://dl.ui.com/unifi/10.1.83/unifi_sysvinit_all.deb" \
+    \
     && dpkg --install /tmp/unifi.deb \
     && apt-get -f install -y \
-    \
     && apt-get clean \
-    && rm -rf \
+    && rm -fr \
         /tmp/* \
         /var/cache/* \
         /var/lib/apt/lists/* \
         /var/log/*.log \
         /var/log/apt
 
+# Copy root filesystem
 COPY rootfs /
 
+# Health check
 HEALTHCHECK --start-period=5m \
     CMD curl --insecure --fail https://localhost:8443 || exit 1
 
+# Build arguments
 ARG BUILD_ARCH
 ARG BUILD_DATE
 ARG BUILD_DESCRIPTION
@@ -53,6 +57,7 @@ ARG BUILD_REF
 ARG BUILD_REPOSITORY
 ARG BUILD_VERSION
 
+# Labels
 LABEL \
     io.hass.name="${BUILD_NAME}" \
     io.hass.description="${BUILD_DESCRIPTION}" \

--- a/unifi/Dockerfile
+++ b/unifi/Dockerfile
@@ -10,10 +10,9 @@ RUN \
     apt-get update \
     && apt-get upgrade -y \
     && apt-get install -y --no-install-recommends \
-        ca-certificates \
-        curl \
-        gnupg \
-        apt-transport-https \
+        ca-certificates=20230311ubuntu0.22.04.1 \
+        gnupg=2.2.27-3ubuntu2.1 \
+        apt-transport-https=2.4.11 \
         binutils=2.34-6ubuntu1.11 \
         libcap2=1:2.32-1ubuntu0.2 \
         logrotate=3.14.0-4ubuntu3 \
@@ -26,7 +25,7 @@ RUN \
         > /etc/apt/sources.list.d/adoptium.list \
     && apt-get update \
     && apt-get install -y --no-install-recommends \
-        temurin-25-jre \
+        temurin-25-jre=25.0.2+10-1~jammy \
     \
     && curl -J -L -o /tmp/unifi.deb \
         "https://dl.ui.com/unifi/10.1.83/unifi_sysvinit_all.deb" \


### PR DESCRIPTION
Changelog: https://community.ui.com/releases/UniFi-Network-Application-10-1-83/36112277-72db-4b1e-a2bb-ae4648932f49


This adds `temurin-25-jre` to support 10.1

Confirmed to upgrade OK from prior Java versions (and Unifi Controller 10.0)




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Upgraded Java runtime from OpenJDK 17 to Temurin 25 JRE with repository and signing key setup for consistent installs.
  * Updated UniFi controller package to version 10.1.83.
  * Added specific package versions for system utilities and improved package installation steps (including immediate dependency resolution) to enhance installation stability and reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->