### PR TITLE
Fix x86_64 SIGILL crash: correct TURN patch offsets and use full NOP sled

### DIFF
--- a/unifi/Dockerfile
+++ b/unifi/Dockerfile
@@ -48,24 +48,35 @@ RUN \
     && X86_64_LIB="/usr/lib/unifi/lib/native/Linux/x86_64/libubnt_webrtc_jni.so" \
     && echo "27e786235fae4a052bc808c3c13dfc19  ${AARCH64_LIB}" | md5sum --check \
     && echo "657963ca47b185baf4eef8d90b70755b  ${X86_64_LIB}" | md5sum --check \
+    # Helper: verify byte sequence at offset in library matches expected hex string.
+    # On mismatch, emit a descriptive failure message and exit non-zero.
+    && verify_bytes() { \
+        local lib="$1" off="$2" count="$3" expect="$4" label="$5"; \
+        local actual; \
+        actual="$(dd if="${lib}" bs=1 skip=$((off)) count="${count}" 2>/dev/null | od -An -tx1 | tr -d ' \n')"; \
+        if [ "${actual}" != "${expect}" ]; then \
+            echo "FAIL: ${label} at $(printf '0x%X' "${off}"): expected ${expect}, got ${actual}" >&2; \
+            return 1; \
+        fi; \
+    } \
     # Sanity-check target bytes before patching. Each offset must point to the
     # opcode for "mov type, #0x1a" that precedes AppendFieldEmpty.
     # aarch64: full 4-byte instruction 0x52800342 (mov w2, #0x1a), little-endian
     # x86_64:  5-byte instruction 0xba 0x1a 0x00 0x00 0x00 (mov edx, 0x1a)
-    && test "$(dd if=${AARCH64_LIB} bs=1 skip=$((0x167214)) count=4 2>/dev/null | od -An -tx1 | tr -d ' \n')" = "42038052" \
-    && test "$(dd if=${AARCH64_LIB} bs=1 skip=$((0x167D20)) count=4 2>/dev/null | od -An -tx1 | tr -d ' \n')" = "42038052" \
-    && test "$(dd if=${X86_64_LIB} bs=1 skip=$((0x114CB9)) count=5 2>/dev/null | od -An -tx1 | tr -d ' \n')" = "ba1a000000" \
-    && test "$(dd if=${X86_64_LIB} bs=1 skip=$((0x1157D7)) count=5 2>/dev/null | od -An -tx1 | tr -d ' \n')" = "ba1a000000" \
+    && verify_bytes "${AARCH64_LIB}" $((0x167214)) 4 "42038052" "aarch64 pre-patch site 1" \
+    && verify_bytes "${AARCH64_LIB}" $((0x167D20)) 4 "42038052" "aarch64 pre-patch site 2" \
+    && verify_bytes "${X86_64_LIB}"  $((0x114CB9)) 5 "ba1a000000" "x86_64 pre-patch site 1" \
+    && verify_bytes "${X86_64_LIB}"  $((0x1157D7)) 5 "ba1a000000" "x86_64 pre-patch site 2" \
     # Apply the patches
     && printf '\x1f\x20\x03\xd5' | dd of="${AARCH64_LIB}" bs=1 seek=$((0x167214)) count=4 conv=notrunc 2>/dev/null \
     && printf '\x1f\x20\x03\xd5' | dd of="${AARCH64_LIB}" bs=1 seek=$((0x167D20)) count=4 conv=notrunc 2>/dev/null \
     && printf '\x90\x90\x90\x90\x90' | dd of="${X86_64_LIB}" bs=1 seek=$((0x114CB9)) count=5 conv=notrunc 2>/dev/null \
     && printf '\x90\x90\x90\x90\x90' | dd of="${X86_64_LIB}" bs=1 seek=$((0x1157D7)) count=5 conv=notrunc 2>/dev/null \
     # Verify patches actually landed
-    && test "$(dd if=${AARCH64_LIB} bs=1 skip=$((0x167214)) count=4 2>/dev/null | od -An -tx1 | tr -d ' \n')" = "1f2003d5" \
-    && test "$(dd if=${AARCH64_LIB} bs=1 skip=$((0x167D20)) count=4 2>/dev/null | od -An -tx1 | tr -d ' \n')" = "1f2003d5" \
-    && test "$(dd if=${X86_64_LIB} bs=1 skip=$((0x114CB9)) count=5 2>/dev/null | od -An -tx1 | tr -d ' \n')" = "9090909090" \
-    && test "$(dd if=${X86_64_LIB} bs=1 skip=$((0x1157D7)) count=5 2>/dev/null | od -An -tx1 | tr -d ' \n')" = "9090909090" \
+    && verify_bytes "${AARCH64_LIB}" $((0x167214)) 4 "1f2003d5" "aarch64 post-patch site 1" \
+    && verify_bytes "${AARCH64_LIB}" $((0x167D20)) 4 "1f2003d5" "aarch64 post-patch site 2" \
+    && verify_bytes "${X86_64_LIB}"  $((0x114CB9)) 5 "9090909090" "x86_64 post-patch site 1" \
+    && verify_bytes "${X86_64_LIB}"  $((0x1157D7)) 5 "9090909090" "x86_64 post-patch site 2" \
     \
     && apt-get clean \
     && rm -fr \

--- a/unifi/Dockerfile
+++ b/unifi/Dockerfile
@@ -48,10 +48,24 @@ RUN \
     && X86_64_LIB="/usr/lib/unifi/lib/native/Linux/x86_64/libubnt_webrtc_jni.so" \
     && echo "27e786235fae4a052bc808c3c13dfc19  ${AARCH64_LIB}" | md5sum --check \
     && echo "657963ca47b185baf4eef8d90b70755b  ${X86_64_LIB}" | md5sum --check \
+    # Sanity-check target bytes before patching. Each offset must point to the
+    # opcode for "mov type, #0x1a" that precedes AppendFieldEmpty.
+    # aarch64: full 4-byte instruction 0x52800342 (mov w2, #0x1a), little-endian
+    # x86_64:  5-byte instruction 0xba 0x1a 0x00 0x00 0x00 (mov edx, 0x1a)
+    && test "$(dd if=${AARCH64_LIB} bs=1 skip=$((0x167214)) count=4 2>/dev/null | od -An -tx1 | tr -d ' \n')" = "42038052" \
+    && test "$(dd if=${AARCH64_LIB} bs=1 skip=$((0x167D20)) count=4 2>/dev/null | od -An -tx1 | tr -d ' \n')" = "42038052" \
+    && test "$(dd if=${X86_64_LIB} bs=1 skip=$((0x114CB9)) count=5 2>/dev/null | od -An -tx1 | tr -d ' \n')" = "ba1a000000" \
+    && test "$(dd if=${X86_64_LIB} bs=1 skip=$((0x1157D7)) count=5 2>/dev/null | od -An -tx1 | tr -d ' \n')" = "ba1a000000" \
+    # Apply the patches
     && printf '\x1f\x20\x03\xd5' | dd of="${AARCH64_LIB}" bs=1 seek=$((0x167214)) count=4 conv=notrunc 2>/dev/null \
     && printf '\x1f\x20\x03\xd5' | dd of="${AARCH64_LIB}" bs=1 seek=$((0x167D20)) count=4 conv=notrunc 2>/dev/null \
-    && printf '\x90' | dd of="${X86_64_LIB}" bs=1 seek=$((0x114D1F)) count=1 conv=notrunc 2>/dev/null \
-    && printf '\x90' | dd of="${X86_64_LIB}" bs=1 seek=$((0x11583D)) count=1 conv=notrunc 2>/dev/null \
+    && printf '\x90\x90\x90\x90\x90' | dd of="${X86_64_LIB}" bs=1 seek=$((0x114CB9)) count=5 conv=notrunc 2>/dev/null \
+    && printf '\x90\x90\x90\x90\x90' | dd of="${X86_64_LIB}" bs=1 seek=$((0x1157D7)) count=5 conv=notrunc 2>/dev/null \
+    # Verify patches actually landed
+    && test "$(dd if=${AARCH64_LIB} bs=1 skip=$((0x167214)) count=4 2>/dev/null | od -An -tx1 | tr -d ' \n')" = "1f2003d5" \
+    && test "$(dd if=${AARCH64_LIB} bs=1 skip=$((0x167D20)) count=4 2>/dev/null | od -An -tx1 | tr -d ' \n')" = "1f2003d5" \
+    && test "$(dd if=${X86_64_LIB} bs=1 skip=$((0x114CB9)) count=5 2>/dev/null | od -An -tx1 | tr -d ' \n')" = "9090909090" \
+    && test "$(dd if=${X86_64_LIB} bs=1 skip=$((0x1157D7)) count=5 2>/dev/null | od -An -tx1 | tr -d ' \n')" = "9090909090" \
     \
     && apt-get clean \
     && rm -fr \


### PR DESCRIPTION
Fixes #635.

## Root cause

The x86_64 patch offsets introduced in #631 (`0x114D1F`, `0x11583D`) were **102 bytes off**. They were derived from a corrupted extraction of `libubnt_webrtc_jni.so` that had `md5sum` output accidentally prepended to the ELF header. The 102-byte text prefix shifted every derived offset by the same amount.

The corruption was caught and the committed binary was re-extracted cleanly, but the shifted offsets were retained. The md5 check was added after that point, so it couldn't catch that the offsets were now wrong. aarch64 was unaffected because its extraction was clean.

At the wrong x86_64 offsets, the single `0x90` NOP byte was written into the middle of unrelated instructions (`lock xadd`, `cmp`, etc.), producing a malformed instruction stream. The crash PC `0x115841` reported in #635 is exactly 4 bytes past the broken write at `0x11583D`, inside the resulting garbage.

## What this PR changes

**Correct x86_64 offsets.** The actual `mov edx, 0x1a` pattern in the pristine library is at `0x114CB9` and `0x1157D7`:
```python
>>> data[0x114CB9:0x114CBE].hex()  # pristine library
'ba1a000000'  # mov edx, 0x1a
>>> data[0x1157D7:0x1157DC].hex()
'ba1a000000'  # mov edx, 0x1a
```

**5-byte NOP sled instead of 1-byte.** `mov edx, 0x1a` on x86_64 is a 5-byte instruction (`ba 1a 00 00 00`). A 1-byte NOP leaves the immediate bytes `1a 00 00 00` in place, which the CPU decodes as garbage instructions (`sbb al, [rax]` + `add [rax], al`) and faults with SIGILL when `rax` doesn't point to writable memory. The 5-byte NOP cleanly replaces the whole instruction. The subsequent `mov rsi, rbx` and `call AppendFieldEmpty` still execute, with `edx` retaining its prior value, matching the behavior on aarch64 (which NOPs the 4-byte `mov w2, #0x1a` but leaves the `bl` call intact).

**Pre-patch and post-patch byte verification.** The build now explicitly checks that each target offset contains the expected opcode *before* applying the patch, and that the NOPs are actually written *after*. This would have caught the original offset bug at build time.

## Testing

I was unable to runtime-reproduce the #635 crash locally (requires a populated HAOS install with remote access enabled). I did verify:

- Pristine library md5 matches the expected value in the Dockerfile
- The correct offsets contain `ba 1a 00 00 00` (the `mov edx, 0x1a` opcode)
- The previous offsets point at unrelated bytes that would produce the observed crash when 1-byte NOP'd
- The build succeeds with pre/post-patch byte verification

It would help to have @charlesomer (the #635 reporter) confirm the fix on their amd64 HAOS install before merging.

## Apologies

The original extraction bug and shifted offsets were my mistake in #631. Sorry for the followup.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced Docker build verification to ensure binary modifications are correctly applied across supported architectures, improving build reliability and process integrity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->